### PR TITLE
Fixed relative value being too low.

### DIFF
--- a/Component.cs
+++ b/Component.cs
@@ -229,7 +229,7 @@ namespace LiveSplit.MemoryGraph
                                      settings.ValueTextPosition == Position.Right);
 
             // calculate relative value between 0 and 1
-            float relativeValue = (currentValue - settings.MinimumValue) / settings.MaximumValue;
+            float relativeValue = (currentValue - settings.MinimumValue) / (settings.MaximumValue - settings.MinimumValue);
 
             // create brush
             switch (settings.GraphGradient)


### PR DESCRIPTION
Expected: Setting Minimum = 20 and Maximum = 80 would draw GraphColor2 pure at 80.

Result: GraphColor2 draws pure at 100.

(0 - 20) / 80 => -.25
(20 - 20) / 80 => 0
(40 - 20) / 80 => .25
(60 - 20) / 80 => .5
(80 - 20) / 80 => .75
(100 - 20) / 80 => 1.0

Fix: Subtract the min value from the divisor:

(0 - 20) / (80 - 20) => -.333
(20 - 20) / (80 - 20) => 0
(40 - 20) / (80 - 20) => .333
(60 - 20) / (80 - 20) => .666
(80 - 20) / (80 - 20) => 1.0
(100 - 20) / (80 - 20)  => 1.333