### PR TITLE
N-Color Gradients

### DIFF
--- a/Component.cs
+++ b/Component.cs
@@ -225,9 +225,9 @@ namespace LiveSplit.MemoryGraph
             }
         }
 
-        private static Color Blend(IEnumerable<Color> colors, double amount, bool sillyColors)
+        private static Color Blend(IEnumerable<Color> colors, float amount, bool sillyColors)
         {
-            if (amount <= 0 || colors.Count() == 1)
+            if (float.IsNaN(amount) || amount <= 0 || colors.Count() == 1)
             {
                 return colors.First();
             }
@@ -249,11 +249,6 @@ namespace LiveSplit.MemoryGraph
 
             // Pick the highest index as the above value rounded up: [1, colors.Count() - 1]
             var index = (int)Math.Ceiling(floatingIndex);
-            if (index <= 0)
-            {
-                // TODO: This should be impossible.
-                return colors.First();
-            }
             var color1 = colors.Skip(index - 1).First();
             var color2 = colors.Skip(index).First();
 

--- a/Component.cs
+++ b/Component.cs
@@ -238,19 +238,17 @@ namespace LiveSplit.MemoryGraph
                     return BlendTwo(colors.Reverse().Skip(1).First(), colors.Last(), amount);
                 }
             }
+            
+            var floatingIndex = amount * (colors.Count() - 1);
 
-            var steps = colors.Count() - 1;
-            var leap = 1.0 / steps;
-
-            var index = (int)Math.Ceiling(amount * steps);
+            var index = (int)Math.Ceiling(floatingIndex);
             if (index == 0)
             {
                 return colors.First();
             }
-
             var color1 = colors.Skip(index - 1).First();
             var color2 = colors.Skip(index).First();
-            return BlendTwo(color1, color2, (amount - (index - 1) * leap) / leap);
+            return BlendTwo(color1, color2, floatingIndex - (index - 1));
         }
 
         private static Color BlendTwo(Color color2, Color color1, double amount)

--- a/Component.cs
+++ b/Component.cs
@@ -308,35 +308,43 @@ namespace LiveSplit.MemoryGraph
             switch (settings.GraphGradient)
             {
                 case GraphGradientType.Plain:
-                    graphBrush = new SolidBrush(settings.GraphColor);
+                    graphBrush = new SolidBrush(settings.GraphColorsEnumeration.First());
                     graphPen.Brush = graphBrush;
                     break;
                 case GraphGradientType.Horizontal:
+                    var cb1 = new ColorBlend
+                    {
+                        Colors = settings.GraphColorsEnumeration.Reverse().ToArray()
+                    };
+                    var pos1 = 0;
+                    cb1.Positions = cb1.Colors.Select(x => pos1++ / (cb1.Colors.Length - 1f)).ToArray();
                     graphBrush = new LinearGradientBrush(graphRect,
-                                                         settings.GraphColor,
-                                                         settings.GraphColor2,
-                                                         LinearGradientMode.Horizontal);
+                                                         Color.Black,
+                                                         Color.Black,
+                                                         LinearGradientMode.Horizontal)
+                    {
+                        InterpolationColors = cb1
+                    };
                     graphPen.Brush = graphBrush;
                     break;
                 case GraphGradientType.Vertical:
-                    var cb = new ColorBlend
+                    var cb2 = new ColorBlend
                     {
-                        Colors = ((IEnumerable<Color>)(settings.GraphColors.Any() ? settings.GraphColors : new List<Color> { Settings.DefaultGraphColor })).Reverse().ToArray()
+                        Colors = settings.GraphColorsEnumeration.Reverse().ToArray()
                     };
-                    var pos = 0;
-                    cb.Positions = cb.Colors.Select(x => pos++ / (cb.Colors.Length - 1f)).ToArray();
+                    var pos2 = 0;
+                    cb2.Positions = cb2.Colors.Select(x => pos2++ / (cb2.Colors.Length - 1f)).ToArray();
                     graphBrush = new LinearGradientBrush(new Point(0, 0),
                                                          new Point(0, graphHeight),
                                                          Color.Black,
                                                          Color.Black)
                     {
-                        InterpolationColors = cb
+                        InterpolationColors = cb2
                     };
-
                     graphPen.Brush = graphBrush;
                     break;
                 case GraphGradientType.ByValue:
-                    graphBrush = new SolidBrush(Blend(settings.GraphColors.Any() ? settings.GraphColors : new List<Color> { Settings.DefaultGraphColor },
+                    graphBrush = new SolidBrush(Blend(settings.GraphColorsEnumeration,
                                                 relativeValue, settings.GraphSillyColors));
                     graphPen.Brush = graphBrush;
                     break;

--- a/Component.cs
+++ b/Component.cs
@@ -227,7 +227,12 @@ namespace LiveSplit.MemoryGraph
 
         private static Color Blend(IEnumerable<Color> colors, double amount, bool sillyColors)
         {
-            if (amount > 1)
+            if (amount == 0)
+            {
+                return colors.First();
+            }
+
+            if (amount >= 1)
             {
                 if (!sillyColors)
                 {
@@ -238,25 +243,25 @@ namespace LiveSplit.MemoryGraph
                     return BlendTwo(colors.Reverse().Skip(1).First(), colors.Last(), amount);
                 }
             }
-            
+
+            // Stretch the amount to cover then range (0, colors.Count() - 1).
             var floatingIndex = amount * (colors.Count() - 1);
 
+            // Pick the highest index as the above value rounded up: [1, colors.Count() - 1]
             var index = (int)Math.Ceiling(floatingIndex);
-            if (index == 0)
-            {
-                return colors.First();
-            }
             var color1 = colors.Skip(index - 1).First();
             var color2 = colors.Skip(index).First();
+
+            // Blend with the decimal part of the floatingIndex.
             return BlendTwo(color1, color2, floatingIndex - (index - 1));
         }
 
-        private static Color BlendTwo(Color color2, Color color1, double amount)
+        private static Color BlendTwo(Color zeroColor, Color oneColor, double amount)
         {
-            byte a = (byte)((color1.A * amount) + color2.A * (1 - amount));
-            byte r = (byte)((color1.R * amount) + color2.R * (1 - amount));
-            byte g = (byte)((color1.G * amount) + color2.G * (1 - amount));
-            byte b = (byte)((color1.B * amount) + color2.B * (1 - amount));
+            byte a = (byte)((oneColor.A * amount) + zeroColor.A * (1 - amount));
+            byte r = (byte)((oneColor.R * amount) + zeroColor.R * (1 - amount));
+            byte g = (byte)((oneColor.G * amount) + zeroColor.G * (1 - amount));
+            byte b = (byte)((oneColor.B * amount) + zeroColor.B * (1 - amount));
             return Color.FromArgb(a, r, g, b);
         }
 

--- a/Component.cs
+++ b/Component.cs
@@ -319,10 +319,20 @@ namespace LiveSplit.MemoryGraph
                     graphPen.Brush = graphBrush;
                     break;
                 case GraphGradientType.Vertical:
+                    var cb = new ColorBlend
+                    {
+                        Colors = ((IEnumerable<Color>)(settings.GraphColors.Any() ? settings.GraphColors : new List<Color> { Settings.DefaultGraphColor })).Reverse().ToArray()
+                    };
+                    var pos = 0;
+                    cb.Positions = cb.Colors.Select(x => pos++ / (cb.Colors.Length - 1f)).ToArray();
                     graphBrush = new LinearGradientBrush(new Point(0, 0),
                                                          new Point(0, graphHeight),
-                                                         settings.GraphColor2,
-                                                         settings.GraphColor);
+                                                         Color.Black,
+                                                         Color.Black)
+                    {
+                        InterpolationColors = cb
+                    };
+
                     graphPen.Brush = graphBrush;
                     break;
                 case GraphGradientType.ByValue:

--- a/Component.cs
+++ b/Component.cs
@@ -229,6 +229,7 @@ namespace LiveSplit.MemoryGraph
         {
             if (float.IsNaN(amount) || amount <= 0 || colors.Count() == 1)
             {
+                // If the amount is in error, default to the first color.
                 return colors.First();
             }
 
@@ -236,6 +237,7 @@ namespace LiveSplit.MemoryGraph
             {
                 if (!sillyColors)
                 {
+                    // No need to blend: we know the last color will provide 100% of the value.
                     return colors.Last();
                 }
                 else
@@ -249,6 +251,7 @@ namespace LiveSplit.MemoryGraph
 
             // Pick the highest index as the above value rounded up: [1, colors.Count() - 1]
             var index = (int)Math.Ceiling(floatingIndex);
+
             var color1 = colors.Skip(index - 1).First();
             var color2 = colors.Skip(index).First();
 

--- a/Component.cs
+++ b/Component.cs
@@ -323,10 +323,8 @@ namespace LiveSplit.MemoryGraph
                     graphPen.Brush = graphBrush;
                     break;
                 case GraphGradientType.ByValue:
-                    graphBrush = new SolidBrush(Blend(new Color[] { settings.GraphColor,
-                                                      settings.GraphColor2 }.Concat(
-                                                      settings.GraphExtraColors),
-                                                      relativeValue, settings.GraphSillyColors));
+                    graphBrush = new SolidBrush(Blend(settings.GraphColors.Any() ? settings.GraphColors : new List<Color> { Settings.DefaultGraphColor },
+                                                relativeValue, settings.GraphSillyColors));
                     graphPen.Brush = graphBrush;
                     break;
             }

--- a/Component.cs
+++ b/Component.cs
@@ -227,7 +227,7 @@ namespace LiveSplit.MemoryGraph
 
         private static Color Blend(IEnumerable<Color> colors, double amount, bool sillyColors)
         {
-            if (amount == 0)
+            if (amount <= 0 || colors.Count() == 1)
             {
                 return colors.First();
             }
@@ -249,6 +249,11 @@ namespace LiveSplit.MemoryGraph
 
             // Pick the highest index as the above value rounded up: [1, colors.Count() - 1]
             var index = (int)Math.Ceiling(floatingIndex);
+            if (index <= 0)
+            {
+                // TODO: This should be impossible.
+                return colors.First();
+            }
             var color1 = colors.Skip(index - 1).First();
             var color2 = colors.Skip(index).First();
 

--- a/Settings.Designer.cs
+++ b/Settings.Designer.cs
@@ -203,7 +203,7 @@ namespace LiveSplit.MemoryGraph
             // 
             // tbMeterToGameUnit
             // 
-            this.tbMeterToGameUnit.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)
+            this.tbMeterToGameUnit.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.tbMeterToGameUnit.Location = new System.Drawing.Point(181, 126);
             this.tbMeterToGameUnit.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
@@ -224,7 +224,7 @@ namespace LiveSplit.MemoryGraph
             // 
             // label3
             // 
-            this.label3.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)
+            this.label3.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.label3.AutoSize = true;
             this.label3.Location = new System.Drawing.Point(107, 129);
@@ -235,7 +235,7 @@ namespace LiveSplit.MemoryGraph
             // 
             // label2
             // 
-            this.label2.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)
+            this.label2.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.label2.AutoSize = true;
             this.label2.Location = new System.Drawing.Point(217, 101);
@@ -246,7 +246,7 @@ namespace LiveSplit.MemoryGraph
             // 
             // cmbUnitsUsed
             // 
-            this.cmbUnitsUsed.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)
+            this.cmbUnitsUsed.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.cmbUnitsUsed.FormattingEnabled = true;
             this.cmbUnitsUsed.Location = new System.Drawing.Point(267, 98);
@@ -270,7 +270,7 @@ namespace LiveSplit.MemoryGraph
             // 
             // grpPointerPath
             // 
-            this.grpPointerPath.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+            this.grpPointerPath.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.grpPointerPath.Controls.Add(this.L_Requires);
             this.grpPointerPath.Controls.Add(this.linkLabel_AdditionalFiles);
@@ -313,7 +313,7 @@ namespace LiveSplit.MemoryGraph
             // 
             // ComboBox_ListOfGames
             // 
-            this.ComboBox_ListOfGames.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+            this.ComboBox_ListOfGames.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.ComboBox_ListOfGames.FormattingEnabled = true;
             this.ComboBox_ListOfGames.Location = new System.Drawing.Point(84, 18);
@@ -346,7 +346,7 @@ namespace LiveSplit.MemoryGraph
             // 
             // txtProcessName
             // 
-            this.txtProcessName.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)
+            this.txtProcessName.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.txtProcessName.Location = new System.Drawing.Point(132, 128);
             this.txtProcessName.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
@@ -366,8 +366,8 @@ namespace LiveSplit.MemoryGraph
             // 
             // tableLayoutPanel2
             // 
-            this.tableLayoutPanel2.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
-            | System.Windows.Forms.AnchorStyles.Left)
+            this.tableLayoutPanel2.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.tableLayoutPanel2.ColumnCount = 4;
             this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 25F));
@@ -477,7 +477,7 @@ namespace LiveSplit.MemoryGraph
             // 
             // grpGraph
             // 
-            this.grpGraph.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+            this.grpGraph.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.grpGraph.Controls.Add(this.btnDeleteColor);
             this.grpGraph.Controls.Add(this.btnAddColor);
@@ -504,7 +504,7 @@ namespace LiveSplit.MemoryGraph
             // btnDeleteColor
             // 
             this.btnDeleteColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnDeleteColor.Location = new System.Drawing.Point(121, 199);
+            this.btnDeleteColor.Location = new System.Drawing.Point(164, 204);
             this.btnDeleteColor.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.btnDeleteColor.Name = "btnDeleteColor";
             this.btnDeleteColor.Size = new System.Drawing.Size(24, 25);
@@ -516,7 +516,7 @@ namespace LiveSplit.MemoryGraph
             // btnAddColor
             // 
             this.btnAddColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnAddColor.Location = new System.Drawing.Point(91, 199);
+            this.btnAddColor.Location = new System.Drawing.Point(134, 204);
             this.btnAddColor.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.btnAddColor.Name = "btnAddColor";
             this.btnAddColor.Size = new System.Drawing.Size(24, 25);
@@ -539,7 +539,7 @@ namespace LiveSplit.MemoryGraph
             // 
             // cmbGraphGradientType
             // 
-            this.cmbGraphGradientType.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+            this.cmbGraphGradientType.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.cmbGraphGradientType.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cmbGraphGradientType.FormattingEnabled = true;
@@ -645,7 +645,7 @@ namespace LiveSplit.MemoryGraph
             this.cmbValueTextPosition.Location = new System.Drawing.Point(75, 21);
             this.cmbValueTextPosition.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.cmbValueTextPosition.Name = "cmbValueTextPosition";
-            this.cmbValueTextPosition.Size = new System.Drawing.Size(345, 21);
+            this.cmbValueTextPosition.Size = new System.Drawing.Size(244, 21);
             this.cmbValueTextPosition.TabIndex = 1;
             // 
             // lblValueTextPosition
@@ -659,7 +659,7 @@ namespace LiveSplit.MemoryGraph
             // 
             // cmbGraphStyle
             // 
-            this.cmbGraphStyle.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+            this.cmbGraphStyle.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.cmbGraphStyle.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cmbGraphStyle.FormattingEnabled = true;
@@ -671,7 +671,7 @@ namespace LiveSplit.MemoryGraph
             // 
             // tableLayoutPanel5
             // 
-            this.tableLayoutPanel5.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+            this.tableLayoutPanel5.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.tableLayoutPanel5.ColumnCount = 5;
             this.tableLayoutPanel5.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 149F));
@@ -887,7 +887,7 @@ namespace LiveSplit.MemoryGraph
             // 
             // cmbBackgroundGradientType
             // 
-            this.cmbBackgroundGradientType.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+            this.cmbBackgroundGradientType.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.cmbBackgroundGradientType.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cmbBackgroundGradientType.FormattingEnabled = true;

--- a/Settings.Designer.cs
+++ b/Settings.Designer.cs
@@ -77,9 +77,7 @@ namespace LiveSplit.MemoryGraph
             this.overrideControlValueText = new LiveSplit.MemoryGraph.TextStyleOverrideControl();
             this.cmbValueTextPosition = new System.Windows.Forms.ComboBox();
             this.lblValueTextPosition = new System.Windows.Forms.Label();
-            this.btnGraphColor2 = new System.Windows.Forms.Button();
             this.cmbGraphStyle = new System.Windows.Forms.ComboBox();
-            this.btnGraphColor1 = new System.Windows.Forms.Button();
             this.tableLayoutPanel5 = new System.Windows.Forms.TableLayoutPanel();
             this.lblMaximumValue = new System.Windows.Forms.Label();
             this.txtMaximumValue = new System.Windows.Forms.TextBox();
@@ -487,9 +485,7 @@ namespace LiveSplit.MemoryGraph
             this.grpGraph.Controls.Add(this.cmbGraphGradientType);
             this.grpGraph.Controls.Add(this.lblGraphStyle);
             this.grpGraph.Controls.Add(this.grpValueText);
-            this.grpGraph.Controls.Add(this.btnGraphColor2);
             this.grpGraph.Controls.Add(this.cmbGraphStyle);
-            this.grpGraph.Controls.Add(this.btnGraphColor1);
             this.grpGraph.Controls.Add(this.tableLayoutPanel5);
             this.grpGraph.Controls.Add(this.lblGraphColor);
             this.grpGraph.Controls.Add(this.lblBackgroundColor);
@@ -508,7 +504,7 @@ namespace LiveSplit.MemoryGraph
             // btnDeleteColor
             // 
             this.btnDeleteColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnDeleteColor.Location = new System.Drawing.Point(181, 199);
+            this.btnDeleteColor.Location = new System.Drawing.Point(121, 199);
             this.btnDeleteColor.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.btnDeleteColor.Name = "btnDeleteColor";
             this.btnDeleteColor.Size = new System.Drawing.Size(24, 25);
@@ -520,7 +516,7 @@ namespace LiveSplit.MemoryGraph
             // btnAddColor
             // 
             this.btnAddColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnAddColor.Location = new System.Drawing.Point(151, 199);
+            this.btnAddColor.Location = new System.Drawing.Point(91, 199);
             this.btnAddColor.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.btnAddColor.Name = "btnAddColor";
             this.btnAddColor.Size = new System.Drawing.Size(24, 25);
@@ -661,17 +657,6 @@ namespace LiveSplit.MemoryGraph
             this.lblValueTextPosition.TabIndex = 0;
             this.lblValueTextPosition.Text = "Position:";
             // 
-            // btnGraphColor2
-            // 
-            this.btnGraphColor2.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnGraphColor2.Location = new System.Drawing.Point(121, 199);
-            this.btnGraphColor2.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.btnGraphColor2.Name = "btnGraphColor2";
-            this.btnGraphColor2.Size = new System.Drawing.Size(24, 25);
-            this.btnGraphColor2.TabIndex = 5;
-            this.btnGraphColor2.UseVisualStyleBackColor = false;
-            this.btnGraphColor2.Click += new System.EventHandler(this.ColorButtonClick);
-            // 
             // cmbGraphStyle
             // 
             this.cmbGraphStyle.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
@@ -683,17 +668,6 @@ namespace LiveSplit.MemoryGraph
             this.cmbGraphStyle.Name = "cmbGraphStyle";
             this.cmbGraphStyle.Size = new System.Drawing.Size(477, 21);
             this.cmbGraphStyle.TabIndex = 6;
-            // 
-            // btnGraphColor1
-            // 
-            this.btnGraphColor1.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnGraphColor1.Location = new System.Drawing.Point(91, 199);
-            this.btnGraphColor1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.btnGraphColor1.Name = "btnGraphColor1";
-            this.btnGraphColor1.Size = new System.Drawing.Size(24, 25);
-            this.btnGraphColor1.TabIndex = 6;
-            this.btnGraphColor1.UseVisualStyleBackColor = false;
-            this.btnGraphColor1.Click += new System.EventHandler(this.ColorButtonClick);
             // 
             // tableLayoutPanel5
             // 
@@ -1075,8 +1049,6 @@ namespace LiveSplit.MemoryGraph
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.ComboBox ComboBox_ListOfGames;
         private System.Windows.Forms.Label lblGraphColor;
-        private System.Windows.Forms.Button btnGraphColor1;
-        private System.Windows.Forms.Button btnGraphColor2;
         private System.Windows.Forms.ComboBox cmbGraphGradientType;
         private System.Windows.Forms.Label lblBackgroundColor;
         private System.Windows.Forms.ComboBox cmbBackgroundGradientType;

--- a/Settings.Designer.cs
+++ b/Settings.Designer.cs
@@ -65,6 +65,8 @@ namespace LiveSplit.MemoryGraph
             this.lblType = new System.Windows.Forms.Label();
             this.cmbType = new System.Windows.Forms.ComboBox();
             this.grpGraph = new System.Windows.Forms.GroupBox();
+            this.btnDeleteColor = new System.Windows.Forms.Button();
+            this.btnAddColor = new System.Windows.Forms.Button();
             this.colorsCBSillyColors = new System.Windows.Forms.CheckBox();
             this.cmbGraphGradientType = new System.Windows.Forms.ComboBox();
             this.lblGraphStyle = new System.Windows.Forms.Label();
@@ -165,7 +167,7 @@ namespace LiveSplit.MemoryGraph
             this.txtDescriptiveText.Location = new System.Drawing.Point(3, 2);
             this.txtDescriptiveText.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.txtDescriptiveText.Name = "txtDescriptiveText";
-            this.txtDescriptiveText.Size = new System.Drawing.Size(280, 22);
+            this.txtDescriptiveText.Size = new System.Drawing.Size(280, 20);
             this.txtDescriptiveText.TabIndex = 2;
             // 
             // lblDescriptiveTextPosition
@@ -188,7 +190,7 @@ namespace LiveSplit.MemoryGraph
             this.cmbDescriptiveTextPosition.Location = new System.Drawing.Point(382, 2);
             this.cmbDescriptiveTextPosition.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.cmbDescriptiveTextPosition.Name = "cmbDescriptiveTextPosition";
-            this.cmbDescriptiveTextPosition.Size = new System.Drawing.Size(186, 24);
+            this.cmbDescriptiveTextPosition.Size = new System.Drawing.Size(186, 21);
             this.cmbDescriptiveTextPosition.TabIndex = 1;
             // 
             // label5
@@ -197,7 +199,7 @@ namespace LiveSplit.MemoryGraph
             this.label5.AutoSize = true;
             this.label5.Location = new System.Drawing.Point(465, 129);
             this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(99, 17);
+            this.label5.Size = new System.Drawing.Size(73, 13);
             this.label5.TabIndex = 3;
             this.label5.Text = "game units (u)";
             // 
@@ -208,7 +210,7 @@ namespace LiveSplit.MemoryGraph
             this.tbMeterToGameUnit.Location = new System.Drawing.Point(181, 126);
             this.tbMeterToGameUnit.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.tbMeterToGameUnit.Name = "tbMeterToGameUnit";
-            this.tbMeterToGameUnit.Size = new System.Drawing.Size(277, 22);
+            this.tbMeterToGameUnit.Size = new System.Drawing.Size(277, 20);
             this.tbMeterToGameUnit.TabIndex = 2;
             // 
             // label4
@@ -218,7 +220,7 @@ namespace LiveSplit.MemoryGraph
             this.label4.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
             this.label4.Location = new System.Drawing.Point(5, 128);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(94, 17);
+            this.label4.Size = new System.Drawing.Size(74, 13);
             this.label4.TabIndex = 1;
             this.label4.Text = "Conversion:";
             // 
@@ -229,7 +231,7 @@ namespace LiveSplit.MemoryGraph
             this.label3.AutoSize = true;
             this.label3.Location = new System.Drawing.Point(107, 129);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(70, 17);
+            this.label3.Size = new System.Drawing.Size(52, 13);
             this.label3.TabIndex = 0;
             this.label3.Text = "1 meter is";
             // 
@@ -240,7 +242,7 @@ namespace LiveSplit.MemoryGraph
             this.label2.AutoSize = true;
             this.label2.Location = new System.Drawing.Point(217, 101);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(44, 17);
+            this.label2.Size = new System.Drawing.Size(34, 13);
             this.label2.TabIndex = 2;
             this.label2.Text = "Units:";
             // 
@@ -252,7 +254,7 @@ namespace LiveSplit.MemoryGraph
             this.cmbUnitsUsed.Location = new System.Drawing.Point(267, 98);
             this.cmbUnitsUsed.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.cmbUnitsUsed.Name = "cmbUnitsUsed";
-            this.cmbUnitsUsed.Size = new System.Drawing.Size(297, 24);
+            this.cmbUnitsUsed.Size = new System.Drawing.Size(297, 21);
             this.cmbUnitsUsed.TabIndex = 1;
             this.cmbUnitsUsed.SelectedIndexChanged += new System.EventHandler(this.cmbUnitsUsed_SelectedIndexChanged);
             // 
@@ -260,10 +262,10 @@ namespace LiveSplit.MemoryGraph
             // 
             this.unitConversionCB.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.unitConversionCB.AutoSize = true;
-            this.unitConversionCB.Location = new System.Drawing.Point(5, 100);
+            this.unitConversionCB.Location = new System.Drawing.Point(5, 104);
             this.unitConversionCB.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.unitConversionCB.Name = "unitConversionCB";
-            this.unitConversionCB.Size = new System.Drawing.Size(178, 21);
+            this.unitConversionCB.Size = new System.Drawing.Size(137, 17);
             this.unitConversionCB.TabIndex = 0;
             this.unitConversionCB.Text = "Enable Unit Conversion";
             this.unitConversionCB.UseVisualStyleBackColor = true;
@@ -294,7 +296,7 @@ namespace LiveSplit.MemoryGraph
             this.L_Requires.AutoSize = true;
             this.L_Requires.Location = new System.Drawing.Point(5, 46);
             this.L_Requires.Name = "L_Requires";
-            this.L_Requires.Size = new System.Drawing.Size(69, 17);
+            this.L_Requires.Size = new System.Drawing.Size(52, 13);
             this.L_Requires.TabIndex = 11;
             this.L_Requires.Text = "Requires:";
             // 
@@ -304,7 +306,7 @@ namespace LiveSplit.MemoryGraph
             this.linkLabel_AdditionalFiles.LinkArea = new System.Windows.Forms.LinkArea(0, 10);
             this.linkLabel_AdditionalFiles.Location = new System.Drawing.Point(81, 46);
             this.linkLabel_AdditionalFiles.Name = "linkLabel_AdditionalFiles";
-            this.linkLabel_AdditionalFiles.Size = new System.Drawing.Size(72, 17);
+            this.linkLabel_AdditionalFiles.Size = new System.Drawing.Size(55, 13);
             this.linkLabel_AdditionalFiles.TabIndex = 10;
             this.linkLabel_AdditionalFiles.TabStop = true;
             this.linkLabel_AdditionalFiles.Text = "linkLabel1";
@@ -319,7 +321,7 @@ namespace LiveSplit.MemoryGraph
             this.ComboBox_ListOfGames.Location = new System.Drawing.Point(84, 18);
             this.ComboBox_ListOfGames.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.ComboBox_ListOfGames.Name = "ComboBox_ListOfGames";
-            this.ComboBox_ListOfGames.Size = new System.Drawing.Size(345, 24);
+            this.ComboBox_ListOfGames.Size = new System.Drawing.Size(345, 21);
             this.ComboBox_ListOfGames.TabIndex = 9;
             this.ComboBox_ListOfGames.SelectedIndexChanged += new System.EventHandler(this.ComboBox_ListOfGames_SelectedIndexChanged);
             // 
@@ -340,7 +342,7 @@ namespace LiveSplit.MemoryGraph
             this.label1.AutoSize = true;
             this.label1.Location = new System.Drawing.Point(5, 22);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(50, 17);
+            this.label1.Size = new System.Drawing.Size(38, 13);
             this.label1.TabIndex = 7;
             this.label1.Text = "Game:";
             // 
@@ -351,7 +353,7 @@ namespace LiveSplit.MemoryGraph
             this.txtProcessName.Location = new System.Drawing.Point(132, 128);
             this.txtProcessName.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.txtProcessName.Name = "txtProcessName";
-            this.txtProcessName.Size = new System.Drawing.Size(444, 22);
+            this.txtProcessName.Size = new System.Drawing.Size(444, 20);
             this.txtProcessName.TabIndex = 5;
             // 
             // lblProcessName
@@ -360,7 +362,7 @@ namespace LiveSplit.MemoryGraph
             this.lblProcessName.AutoSize = true;
             this.lblProcessName.Location = new System.Drawing.Point(5, 130);
             this.lblProcessName.Name = "lblProcessName";
-            this.lblProcessName.Size = new System.Drawing.Size(120, 17);
+            this.lblProcessName.Size = new System.Drawing.Size(91, 13);
             this.lblProcessName.TabIndex = 4;
             this.lblProcessName.Text = "Name of Process:";
             // 
@@ -408,7 +410,7 @@ namespace LiveSplit.MemoryGraph
             this.txtOffsets.Location = new System.Drawing.Point(227, 26);
             this.txtOffsets.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.txtOffsets.Name = "txtOffsets";
-            this.txtOffsets.Size = new System.Drawing.Size(218, 22);
+            this.txtOffsets.Size = new System.Drawing.Size(218, 20);
             this.txtOffsets.TabIndex = 1;
             this.txtOffsets.Validating += new System.ComponentModel.CancelEventHandler(this.txtOffsets_Validating);
             // 
@@ -418,7 +420,7 @@ namespace LiveSplit.MemoryGraph
             this.txtBase.Location = new System.Drawing.Point(115, 26);
             this.txtBase.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.txtBase.Name = "txtBase";
-            this.txtBase.Size = new System.Drawing.Size(106, 22);
+            this.txtBase.Size = new System.Drawing.Size(106, 20);
             this.txtBase.TabIndex = 1;
             this.txtBase.Validating += new System.ComponentModel.CancelEventHandler(this.txtBase_Validating);
             // 
@@ -428,7 +430,7 @@ namespace LiveSplit.MemoryGraph
             this.txtModule.Location = new System.Drawing.Point(3, 26);
             this.txtModule.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.txtModule.Name = "txtModule";
-            this.txtModule.Size = new System.Drawing.Size(106, 22);
+            this.txtModule.Size = new System.Drawing.Size(106, 20);
             this.txtModule.TabIndex = 1;
             // 
             // lblBase
@@ -472,13 +474,15 @@ namespace LiveSplit.MemoryGraph
             this.cmbType.Location = new System.Drawing.Point(451, 26);
             this.cmbType.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.cmbType.Name = "cmbType";
-            this.cmbType.Size = new System.Drawing.Size(117, 24);
+            this.cmbType.Size = new System.Drawing.Size(117, 21);
             this.cmbType.TabIndex = 4;
             // 
             // grpGraph
             // 
             this.grpGraph.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.grpGraph.Controls.Add(this.btnDeleteColor);
+            this.grpGraph.Controls.Add(this.btnAddColor);
             this.grpGraph.Controls.Add(this.colorsCBSillyColors);
             this.grpGraph.Controls.Add(this.cmbGraphGradientType);
             this.grpGraph.Controls.Add(this.lblGraphStyle);
@@ -501,13 +505,37 @@ namespace LiveSplit.MemoryGraph
             this.grpGraph.TabStop = false;
             this.grpGraph.Text = "Graph";
             // 
+            // btnDeleteColor
+            // 
+            this.btnDeleteColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnDeleteColor.Location = new System.Drawing.Point(181, 199);
+            this.btnDeleteColor.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.btnDeleteColor.Name = "btnDeleteColor";
+            this.btnDeleteColor.Size = new System.Drawing.Size(24, 25);
+            this.btnDeleteColor.TabIndex = 9;
+            this.btnDeleteColor.Text = "-";
+            this.btnDeleteColor.UseVisualStyleBackColor = false;
+            this.btnDeleteColor.Click += new System.EventHandler(this.btnDeleteColor_Click);
+            // 
+            // btnAddColor
+            // 
+            this.btnAddColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnAddColor.Location = new System.Drawing.Point(151, 199);
+            this.btnAddColor.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.btnAddColor.Name = "btnAddColor";
+            this.btnAddColor.Size = new System.Drawing.Size(24, 25);
+            this.btnAddColor.TabIndex = 8;
+            this.btnAddColor.Text = "+";
+            this.btnAddColor.UseVisualStyleBackColor = false;
+            this.btnAddColor.Click += new System.EventHandler(this.btnAddColor_Click);
+            // 
             // colorsCBSillyColors
             // 
             this.colorsCBSillyColors.AutoSize = true;
             this.colorsCBSillyColors.Location = new System.Drawing.Point(9, 204);
             this.colorsCBSillyColors.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.colorsCBSillyColors.Name = "colorsCBSillyColors";
-            this.colorsCBSillyColors.Size = new System.Drawing.Size(99, 21);
+            this.colorsCBSillyColors.Size = new System.Drawing.Size(76, 17);
             this.colorsCBSillyColors.TabIndex = 0;
             this.colorsCBSillyColors.Text = "Silly Colors";
             this.colorsCBSillyColors.UseVisualStyleBackColor = true;
@@ -519,10 +547,10 @@ namespace LiveSplit.MemoryGraph
             | System.Windows.Forms.AnchorStyles.Right)));
             this.cmbGraphGradientType.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cmbGraphGradientType.FormattingEnabled = true;
-            this.cmbGraphGradientType.Location = new System.Drawing.Point(193, 176);
+            this.cmbGraphGradientType.Location = new System.Drawing.Point(133, 176);
             this.cmbGraphGradientType.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.cmbGraphGradientType.Name = "cmbGraphGradientType";
-            this.cmbGraphGradientType.Size = new System.Drawing.Size(383, 24);
+            this.cmbGraphGradientType.Size = new System.Drawing.Size(443, 21);
             this.cmbGraphGradientType.TabIndex = 4;
             this.cmbGraphGradientType.SelectedValueChanged += new System.EventHandler(this.cmbGraphGradientType_SelectedValueChanged);
             // 
@@ -531,15 +559,14 @@ namespace LiveSplit.MemoryGraph
             this.lblGraphStyle.AutoSize = true;
             this.lblGraphStyle.Location = new System.Drawing.Point(5, 23);
             this.lblGraphStyle.Name = "lblGraphStyle";
-            this.lblGraphStyle.Size = new System.Drawing.Size(87, 17);
+            this.lblGraphStyle.Size = new System.Drawing.Size(65, 13);
             this.lblGraphStyle.TabIndex = 5;
             this.lblGraphStyle.Text = "Graph Style:";
             this.lblGraphStyle.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // grpValueText
             // 
-            this.grpValueText.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
+            this.grpValueText.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.grpValueText.Controls.Add(this.localMaxCB);
             this.grpValueText.Controls.Add(this.label5);
@@ -586,7 +613,7 @@ namespace LiveSplit.MemoryGraph
             0,
             0});
             this.numValueTextDecimals.Name = "numValueTextDecimals";
-            this.numValueTextDecimals.Size = new System.Drawing.Size(53, 22);
+            this.numValueTextDecimals.Size = new System.Drawing.Size(53, 20);
             this.numValueTextDecimals.TabIndex = 3;
             // 
             // lblDecimals
@@ -596,7 +623,7 @@ namespace LiveSplit.MemoryGraph
             this.lblDecimals.Location = new System.Drawing.Point(435, 25);
             this.lblDecimals.Margin = new System.Windows.Forms.Padding(13, 0, 3, 0);
             this.lblDecimals.Name = "lblDecimals";
-            this.lblDecimals.Size = new System.Drawing.Size(69, 17);
+            this.lblDecimals.Size = new System.Drawing.Size(53, 13);
             this.lblDecimals.TabIndex = 2;
             this.lblDecimals.Text = "Decimals:";
             // 
@@ -622,7 +649,7 @@ namespace LiveSplit.MemoryGraph
             this.cmbValueTextPosition.Location = new System.Drawing.Point(75, 21);
             this.cmbValueTextPosition.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.cmbValueTextPosition.Name = "cmbValueTextPosition";
-            this.cmbValueTextPosition.Size = new System.Drawing.Size(244, 24);
+            this.cmbValueTextPosition.Size = new System.Drawing.Size(345, 21);
             this.cmbValueTextPosition.TabIndex = 1;
             // 
             // lblValueTextPosition
@@ -630,14 +657,14 @@ namespace LiveSplit.MemoryGraph
             this.lblValueTextPosition.AutoSize = true;
             this.lblValueTextPosition.Location = new System.Drawing.Point(5, 25);
             this.lblValueTextPosition.Name = "lblValueTextPosition";
-            this.lblValueTextPosition.Size = new System.Drawing.Size(62, 17);
+            this.lblValueTextPosition.Size = new System.Drawing.Size(47, 13);
             this.lblValueTextPosition.TabIndex = 0;
             this.lblValueTextPosition.Text = "Position:";
             // 
             // btnGraphColor2
             // 
             this.btnGraphColor2.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnGraphColor2.Location = new System.Drawing.Point(164, 175);
+            this.btnGraphColor2.Location = new System.Drawing.Point(121, 199);
             this.btnGraphColor2.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.btnGraphColor2.Name = "btnGraphColor2";
             this.btnGraphColor2.Size = new System.Drawing.Size(24, 25);
@@ -654,13 +681,13 @@ namespace LiveSplit.MemoryGraph
             this.cmbGraphStyle.Location = new System.Drawing.Point(99, 20);
             this.cmbGraphStyle.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.cmbGraphStyle.Name = "cmbGraphStyle";
-            this.cmbGraphStyle.Size = new System.Drawing.Size(477, 24);
+            this.cmbGraphStyle.Size = new System.Drawing.Size(477, 21);
             this.cmbGraphStyle.TabIndex = 6;
             // 
             // btnGraphColor1
             // 
             this.btnGraphColor1.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnGraphColor1.Location = new System.Drawing.Point(133, 175);
+            this.btnGraphColor1.Location = new System.Drawing.Point(91, 199);
             this.btnGraphColor1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.btnGraphColor1.Name = "btnGraphColor1";
             this.btnGraphColor1.Size = new System.Drawing.Size(24, 25);
@@ -717,7 +744,7 @@ namespace LiveSplit.MemoryGraph
             this.txtMaximumValue.Location = new System.Drawing.Point(443, 2);
             this.txtMaximumValue.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.txtMaximumValue.Name = "txtMaximumValue";
-            this.txtMaximumValue.Size = new System.Drawing.Size(125, 22);
+            this.txtMaximumValue.Size = new System.Drawing.Size(125, 20);
             this.txtMaximumValue.TabIndex = 6;
             this.txtMaximumValue.Validating += new System.ComponentModel.CancelEventHandler(this.txtMaximumValue_Validating);
             // 
@@ -749,7 +776,7 @@ namespace LiveSplit.MemoryGraph
             this.txtMinimumValue.Location = new System.Drawing.Point(152, 2);
             this.txtMinimumValue.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.txtMinimumValue.Name = "txtMinimumValue";
-            this.txtMinimumValue.Size = new System.Drawing.Size(125, 22);
+            this.txtMinimumValue.Size = new System.Drawing.Size(125, 20);
             this.txtMinimumValue.TabIndex = 5;
             this.txtMinimumValue.Validating += new System.ComponentModel.CancelEventHandler(this.txtMinimumValue_Validating);
             // 
@@ -764,7 +791,7 @@ namespace LiveSplit.MemoryGraph
             0,
             0});
             this.numHeight.Name = "numHeight";
-            this.numHeight.Size = new System.Drawing.Size(125, 22);
+            this.numHeight.Size = new System.Drawing.Size(125, 20);
             this.numHeight.TabIndex = 7;
             // 
             // lblHeight
@@ -800,7 +827,7 @@ namespace LiveSplit.MemoryGraph
             0,
             0});
             this.numWidth.Name = "numWidth";
-            this.numWidth.Size = new System.Drawing.Size(125, 22);
+            this.numWidth.Size = new System.Drawing.Size(125, 20);
             this.numWidth.TabIndex = 10;
             // 
             // lblVerticalMargins
@@ -825,7 +852,7 @@ namespace LiveSplit.MemoryGraph
             0,
             0});
             this.numVerticalMargins.Name = "numVerticalMargins";
-            this.numVerticalMargins.Size = new System.Drawing.Size(125, 22);
+            this.numVerticalMargins.Size = new System.Drawing.Size(125, 20);
             this.numVerticalMargins.TabIndex = 12;
             // 
             // numHorizontalMargins
@@ -839,7 +866,7 @@ namespace LiveSplit.MemoryGraph
             0,
             0});
             this.numHorizontalMargins.Name = "numHorizontalMargins";
-            this.numHorizontalMargins.Size = new System.Drawing.Size(125, 22);
+            this.numHorizontalMargins.Size = new System.Drawing.Size(125, 20);
             this.numHorizontalMargins.TabIndex = 13;
             // 
             // lblGraphColor
@@ -847,7 +874,7 @@ namespace LiveSplit.MemoryGraph
             this.lblGraphColor.AutoSize = true;
             this.lblGraphColor.Location = new System.Drawing.Point(5, 178);
             this.lblGraphColor.Name = "lblGraphColor";
-            this.lblGraphColor.Size = new System.Drawing.Size(89, 17);
+            this.lblGraphColor.Size = new System.Drawing.Size(66, 13);
             this.lblGraphColor.TabIndex = 7;
             this.lblGraphColor.Text = "Graph Color:";
             this.lblGraphColor.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -857,7 +884,7 @@ namespace LiveSplit.MemoryGraph
             this.lblBackgroundColor.AutoSize = true;
             this.lblBackgroundColor.Location = new System.Drawing.Point(5, 150);
             this.lblBackgroundColor.Name = "lblBackgroundColor";
-            this.lblBackgroundColor.Size = new System.Drawing.Size(125, 17);
+            this.lblBackgroundColor.Size = new System.Drawing.Size(95, 13);
             this.lblBackgroundColor.TabIndex = 0;
             this.lblBackgroundColor.Text = "Background Color:";
             this.lblBackgroundColor.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -893,7 +920,7 @@ namespace LiveSplit.MemoryGraph
             this.cmbBackgroundGradientType.Location = new System.Drawing.Point(193, 146);
             this.cmbBackgroundGradientType.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.cmbBackgroundGradientType.Name = "cmbBackgroundGradientType";
-            this.cmbBackgroundGradientType.Size = new System.Drawing.Size(383, 24);
+            this.cmbBackgroundGradientType.Size = new System.Drawing.Size(383, 21);
             this.cmbBackgroundGradientType.TabIndex = 1;
             this.cmbBackgroundGradientType.SelectedValueChanged += new System.EventHandler(this.cmbBackgroundGradientType_SelectedValueChanged);
             // 
@@ -904,7 +931,7 @@ namespace LiveSplit.MemoryGraph
             this.Controls.Add(this.grpDescriptiveText);
             this.Controls.Add(this.grpPointerPath);
             this.Controls.Add(this.grpGraph);
-            this.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            this.Margin = new System.Windows.Forms.Padding(5);
             this.Name = "Settings";
             this.Padding = new System.Windows.Forms.Padding(12, 11, 12, 11);
             this.Size = new System.Drawing.Size(612, 681);
@@ -1067,5 +1094,7 @@ namespace LiveSplit.MemoryGraph
         private System.Windows.Forms.Label label4;
         private System.Windows.Forms.Label label3;
         private System.Windows.Forms.CheckBox localMaxCB;
+        private System.Windows.Forms.Button btnAddColor;
+        private System.Windows.Forms.Button btnDeleteColor;
     }
 }

--- a/Settings.cs
+++ b/Settings.cs
@@ -343,6 +343,7 @@ namespace LiveSplit.MemoryGraph
             BackgroundColor = SettingsHelper.ParseColor(element["BackgroundColor"]);
             BackgroundColor2 = SettingsHelper.ParseColor(element["BackgroundColor2"]);
             GraphColors.Clear();
+            // GraphColor and GraphColor2 were the old values used to store the GraphColors. If they exist, add their values to our new list of colors.
             var GraphColor = SettingsHelper.ParseColor(element["GraphColor"]);
             if (GraphColor != default(Color))
             {
@@ -353,6 +354,7 @@ namespace LiveSplit.MemoryGraph
             {
                 GraphColors.Add(GraphColor2);
             }
+            // Regular parsing of GraphColors. We can't use a default Parser since it's a list and needs to be comma seperated.
             if (element["GraphColors"] != null)
             {
                 GraphColors.AddRange(element["GraphColors"].InnerText.Split(',').Select(x => Color.FromArgb(int.Parse(x, NumberStyles.HexNumber))));
@@ -521,16 +523,18 @@ namespace LiveSplit.MemoryGraph
                     AddColorButton();
                     break;
 
+                default:
+                case GraphGradientType.Vertical:
+                case GraphGradientType.Horizontal:
+                    AddColorButton();
+                    AddColorButton();
+                    break;
+
                 case GraphGradientType.ByValue:
                     foreach (var color in GraphColors)
                     {
                         AddColorButton();
                     }
-                    break;
-
-                default:
-                    AddColorButton();
-                    AddColorButton();
                     break;
             }
 

--- a/Settings.cs
+++ b/Settings.cs
@@ -520,26 +520,32 @@ namespace LiveSplit.MemoryGraph
             var ggt = (GraphGradientType)cmbGraphGradientType.SelectedValue;
             switch (ggt) {
                 case GraphGradientType.Plain:
+                    btnAddColor.Visible = false;
+                    btnDeleteColor.Visible = false;
+
                     AddColorButton();
                     break;
 
                 default:
-                case GraphGradientType.Vertical:
                 case GraphGradientType.Horizontal:
+                    btnAddColor.Visible = false;
+                    btnDeleteColor.Visible = false;
+
                     AddColorButton();
                     AddColorButton();
                     break;
 
+                case GraphGradientType.Vertical:
                 case GraphGradientType.ByValue:
+                    btnAddColor.Visible = true;
+                    btnDeleteColor.Visible = GraphColorButtons.Skip(2).Any();
+
                     foreach (var color in GraphColors)
                     {
                         AddColorButton();
                     }
                     break;
             }
-
-            btnAddColor.Visible = ggt == GraphGradientType.ByValue;
-            btnDeleteColor.Visible = ggt == GraphGradientType.ByValue && GraphColorButtons.Skip(2).Any();
         }
 
         private void txtBase_Validating(object sender, CancelEventArgs e)

--- a/Settings.cs
+++ b/Settings.cs
@@ -109,6 +109,7 @@ namespace LiveSplit.MemoryGraph
         public Color BackgroundColor2 { get; set; }
         public Color GraphColor { get; set; }
         public Color GraphColor2 { get; set; }
+        public List<Color> GraphExtraColors { get; set; } = new List<Color>();
 
         public float MinimumValue { get; set; }
         public float MaximumValue { get; set; }

--- a/Settings.cs
+++ b/Settings.cs
@@ -110,8 +110,7 @@ namespace LiveSplit.MemoryGraph
         public Color BackgroundColor2 { get; set; }
         public static Color DefaultGraphColor => Color.Red;
         public List<Color> GraphColors { get; set; } = new List<Color>();
-        public Color GraphColor => GraphColors.Any() ? GraphColors.First() : DefaultGraphColor;
-        public Color GraphColor2 => GraphColors.Skip(1).Any() ? GraphColors.Skip(1).First() : DefaultGraphColor;
+        public IEnumerable<Color> GraphColorsEnumeration => GraphColors.Any() ? GraphColors : new List<Color> { DefaultGraphColor };
 
         public float MinimumValue { get; set; }
         public float MaximumValue { get; set; }
@@ -297,7 +296,7 @@ namespace LiveSplit.MemoryGraph
                 UseVisualStyleBackColor = false
             };
             newButton.Click += new EventHandler(ColorButtonClick);
-            newButton.BackColorChanged += new EventHandler(BackColorChanged);
+            newButton.BackColorChanged += new EventHandler(BackColorChangedEvent);
 
             var delta = btnDeleteColor.Location.X - btnAddColor.Location.X;
             btnAddColor.Location = new Point(btnAddColor.Location.X + delta, btnAddColor.Location.Y);
@@ -330,7 +329,7 @@ namespace LiveSplit.MemoryGraph
             btnDeleteColor.Visible = GraphColorButtons.Skip(2).Any();
         }
 
-        private void BackColorChanged(object sender, EventArgs e)
+        private void BackColorChangedEvent(object sender, EventArgs e)
         {
             GraphColors.Clear();
             GraphColors.AddRange(GraphColorButtons.Where(b => b.BackColor != default(Color)).Select(b => b.BackColor));
@@ -518,32 +517,27 @@ namespace LiveSplit.MemoryGraph
                 DeleteColorButton(false);
             }
             var ggt = (GraphGradientType)cmbGraphGradientType.SelectedValue;
-            switch (ggt) {
-                case GraphGradientType.Plain:
-                    btnAddColor.Visible = false;
-                    btnDeleteColor.Visible = false;
-
-                    AddColorButton();
-                    break;
-
+            switch (ggt)
+            {
                 default:
-                case GraphGradientType.Horizontal:
+                case GraphGradientType.Plain:
+                    AddColorButton();
+                    // TODO: Doesn't set the color right on first load!
+
                     btnAddColor.Visible = false;
                     btnDeleteColor.Visible = false;
-
-                    AddColorButton();
-                    AddColorButton();
                     break;
 
                 case GraphGradientType.Vertical:
+                case GraphGradientType.Horizontal:
                 case GraphGradientType.ByValue:
-                    btnAddColor.Visible = true;
-                    btnDeleteColor.Visible = GraphColorButtons.Skip(2).Any();
-
                     foreach (var color in GraphColors)
                     {
                         AddColorButton();
                     }
+
+                    btnAddColor.Visible = true;
+                    btnDeleteColor.Visible = GraphColorButtons.Skip(2).Any();
                     break;
             }
         }

--- a/Settings.cs
+++ b/Settings.cs
@@ -109,7 +109,7 @@ namespace LiveSplit.MemoryGraph
         public Color BackgroundColor2 { get; set; }
         public Color GraphColor { get; set; }
         public Color GraphColor2 { get; set; }
-        public List<Color> GraphExtraColors { get; set; } = new List<Color>();
+        public List<Color> GraphExtraColors { get; set; }
 
         public float MinimumValue { get; set; }
         public float MaximumValue { get; set; }
@@ -169,6 +169,7 @@ namespace LiveSplit.MemoryGraph
             BackgroundColor2 = Color.Transparent;
             GraphColor = Color.Red;
             GraphColor2 = Color.Red;
+            GraphExtraColors = new List<Color>();
             MinimumValue = 0;
             MaximumValue = 1000;
             GraphWidth = 200;

--- a/Settings.cs
+++ b/Settings.cs
@@ -306,6 +306,7 @@ namespace LiveSplit.MemoryGraph
 
             grpGraph.Controls.Add(newButton);
             GraphColorButtons.Add(newButton);
+            btnAddColor.Visible = !GraphColorButtons.Skip(12).Any();
             btnDeleteColor.Visible = GraphColorButtons.Skip(2).Any();
 
             return newButton;
@@ -328,6 +329,7 @@ namespace LiveSplit.MemoryGraph
             {
                 GraphColors.RemoveAt(GraphColors.Count - 1);
             }
+            btnAddColor.Visible = !GraphColorButtons.Skip(12).Any();
             btnDeleteColor.Visible = GraphColorButtons.Skip(2).Any();
         }
 
@@ -539,7 +541,7 @@ namespace LiveSplit.MemoryGraph
                         AddColorButton();
                     }
 
-                    btnAddColor.Visible = true;
+                    btnAddColor.Visible = !GraphColorButtons.Skip(12).Any();
                     btnDeleteColor.Visible = GraphColorButtons.Skip(2).Any();
                     break;
             }

--- a/Settings.cs
+++ b/Settings.cs
@@ -277,7 +277,49 @@ namespace LiveSplit.MemoryGraph
         private void ColorButtonClick(object sender, EventArgs e)
         {
             SettingsHelper.ColorButtonClick((Button)sender, this);
-        }        
+        }
+
+        private List<Button> GraphColorButtons = new List<Button>(); 
+
+        private void btnAddColor_Click(object sender, EventArgs e)
+        {
+            int x;
+            if (GraphColorButtons.Skip(1).Any())
+            {
+                x = 2 * GraphColorButtons.Last().Location.X - ((IEnumerable<Button>)GraphColorButtons).Reverse().Skip(1).First().Location.X;
+            }
+            else if (GraphColorButtons.Any())
+            {
+                x = 2 * GraphColorButtons.First().Location.X - btnGraphColor2.Location.X;
+            }
+            else
+            {
+                x = 2 * btnGraphColor2.Location.X - btnGraphColor1.Location.X;
+            }
+
+            var newButton = new Button
+            {
+                FlatStyle = FlatStyle.Flat,
+                Location = new Point(x, 199),
+                Margin = new Padding(3, 2, 3, 2),
+                Size = new Size(24, 25),
+                UseVisualStyleBackColor = false
+            };
+            newButton.Click += new EventHandler(ColorButtonClick);
+
+            GraphColorButtons.Add(newButton);
+            grpGraph.Controls.Add(newButton);
+            btnDeleteColor.Visible = true;
+
+            SettingsHelper.ColorButtonClick(newButton, this);
+        }
+
+        private void btnDeleteColor_Click(object sender, EventArgs e)
+        {
+            grpGraph.Controls.Remove(GraphColorButtons.Last());
+            GraphColorButtons.RemoveAt(GraphColorButtons.Count - 1);
+            btnDeleteColor.Visible = GraphColorButtons.Any();
+        }
 
         public void SetSettings(System.Xml.XmlNode node)
         {
@@ -443,9 +485,10 @@ namespace LiveSplit.MemoryGraph
                 return;
             }
 
-            btnGraphColor1.Visible = ((GraphGradientType) cmbGraphGradientType.SelectedValue != GraphGradientType.Plain);
-            btnGraphColor2.DataBindings.Clear();
-            btnGraphColor2.DataBindings.Add("BackColor", this, btnGraphColor1.Visible ? "GraphColor2" : "GraphColor", false, DataSourceUpdateMode.OnPropertyChanged);
+            var ggt = (GraphGradientType)cmbGraphGradientType.SelectedValue;
+            btnGraphColor2.Visible = ggt != GraphGradientType.Plain;
+            btnAddColor.Visible = ggt == GraphGradientType.ByValue;
+            btnDeleteColor.Visible = ggt == GraphGradientType.ByValue && GraphColorButtons.Any();
         }
 
         private void txtBase_Validating(object sender, CancelEventArgs e)

--- a/Settings.cs
+++ b/Settings.cs
@@ -290,9 +290,9 @@ namespace LiveSplit.MemoryGraph
             var newButton = new Button
             {
                 FlatStyle = FlatStyle.Flat,
-                Location = new Point(btnAddColor.Location.X, 199),
-                Margin = new Padding(3, 2, 3, 2),
-                Size = new Size(24, 25),
+                Location = new Point(btnAddColor.Location.X, btnAddColor.Location.Y),
+                Margin = btnAddColor.Margin,
+                Size = btnAddColor.Size,
                 BackColor = GraphColors.Skip(GraphColorButtons.Count).FirstOrDefault(),
                 UseVisualStyleBackColor = false
             };


### PR DESCRIPTION
Updated the gradients of the drawn graph from 2-color-max to n-color max.

So, naturally:
![pride](https://user-images.githubusercontent.com/36424682/36343909-84fa0322-13e0-11e8-99c9-ebe6fe8b7d43.png)

Since this can add as many colors as will fit, I had to move the colors to their own line:
![capture](https://user-images.githubusercontent.com/36424682/36343908-814360d4-13e0-11e8-8340-21fc5ca8c955.PNG)

There are some extra deltas from where I edited the Settings.Designer. I'm going to leave these since 1.) they're autogenerated 2.) I'm working on another PR that'll add settings, so the deltas are going to be something I must keep fighting. I bet if you opened the settings up, that'd fix the deltas.

I had to rewrite how the colors were saved. It's now a comma separated list:

`<GraphColors>FFFF00FF,FF0000FF,FF00FFFF,FF00FF00,FFFFFF00,FFFF8000,FFFF0000</GraphColors`

This PR will automatically load the old GraphColor and GraphColor2 settings and convert them to the new format.

This is enabled for all Graph Color formats except Plain, since that's intended to be a single color.

The changes here *can* be applied to the background color, but I'd rather that be its own PR.