### PR TITLE
Fixed Feet per Second Calculation

### DIFF
--- a/Component.cs
+++ b/Component.cs
@@ -631,7 +631,7 @@ namespace LiveSplit.MemoryGraph
                     }
                 case Units.FeetPerSecond:
                     {
-                        float returnValue = (currentValue / multiplier) * 196.850394f;
+                        float returnValue = (currentValue / multiplier) * 3.2808399f;
                         return returnValue.ToString("n" + valueTextDecimals) + " (fps)";
                     }
                 default:


### PR DESCRIPTION
The conversion constant for Feet per Second was giving large numbers. It looks like this was converting to Feet per *Minute*.