### PR TITLE
Game Options

### DIFF
--- a/Downloader.cs
+++ b/Downloader.cs
@@ -14,7 +14,7 @@ namespace LiveSplit.MemoryGraph
         public bool DownloadNew()
         {
             string uriToSource = "https://raw.githubusercontent.com/kugelrund/LiveSplit.MemoryGraph/master/XML/";
-            string xmlFileName = "LiveSplit.MemoryGraph.Games.xml";
+            string xmlFileName = Settings.listsFile;
             bool result = false;
             string downloadedFileLocation = "";
             if (CheckIfXMLExists(uriToSource+ xmlFileName))

--- a/Downloader.cs
+++ b/Downloader.cs
@@ -14,7 +14,7 @@ namespace LiveSplit.MemoryGraph
         public bool DownloadNew()
         {
             string uriToSource = "https://raw.githubusercontent.com/kugelrund/LiveSplit.MemoryGraph/master/XML/";
-            string xmlFileName = "LiveSplit.MemoryGraphList.xml";
+            string xmlFileName = "LiveSplit.MemoryGraph.Games.xml";
             bool result = false;
             string downloadedFileLocation = "";
             if (CheckIfXMLExists(uriToSource+ xmlFileName))

--- a/Settings.Designer.cs
+++ b/Settings.Designer.cs
@@ -48,6 +48,7 @@ namespace LiveSplit.MemoryGraph
             this.cmbUnitsUsed = new System.Windows.Forms.ComboBox();
             this.unitConversionCB = new System.Windows.Forms.CheckBox();
             this.grpPointerPath = new System.Windows.Forms.GroupBox();
+            this.ComboBox_GameVersion = new System.Windows.Forms.ComboBox();
             this.L_Requires = new System.Windows.Forms.Label();
             this.linkLabel_AdditionalFiles = new System.Windows.Forms.LinkLabel();
             this.ComboBox_ListOfGames = new System.Windows.Forms.ComboBox();
@@ -272,6 +273,7 @@ namespace LiveSplit.MemoryGraph
             // 
             this.grpPointerPath.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.grpPointerPath.Controls.Add(this.ComboBox_GameVersion);
             this.grpPointerPath.Controls.Add(this.L_Requires);
             this.grpPointerPath.Controls.Add(this.linkLabel_AdditionalFiles);
             this.grpPointerPath.Controls.Add(this.ComboBox_ListOfGames);
@@ -288,6 +290,18 @@ namespace LiveSplit.MemoryGraph
             this.grpPointerPath.TabIndex = 0;
             this.grpPointerPath.TabStop = false;
             this.grpPointerPath.Text = "Pointer path";
+            // 
+            // ComboBox_GameVersion
+            // 
+            this.ComboBox_GameVersion.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.ComboBox_GameVersion.FormattingEnabled = true;
+            this.ComboBox_GameVersion.Location = new System.Drawing.Point(330, 18);
+            this.ComboBox_GameVersion.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.ComboBox_GameVersion.Name = "ComboBox_GameVersion";
+            this.ComboBox_GameVersion.Size = new System.Drawing.Size(100, 21);
+            this.ComboBox_GameVersion.TabIndex = 12;
+            this.ComboBox_GameVersion.SelectedIndexChanged += new System.EventHandler(this.ComboBox_ListOfGames_SelectedIndexChanged);
             // 
             // L_Requires
             // 
@@ -319,7 +333,7 @@ namespace LiveSplit.MemoryGraph
             this.ComboBox_ListOfGames.Location = new System.Drawing.Point(84, 18);
             this.ComboBox_ListOfGames.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.ComboBox_ListOfGames.Name = "ComboBox_ListOfGames";
-            this.ComboBox_ListOfGames.Size = new System.Drawing.Size(345, 21);
+            this.ComboBox_ListOfGames.Size = new System.Drawing.Size(240, 21);
             this.ComboBox_ListOfGames.TabIndex = 9;
             this.ComboBox_ListOfGames.SelectedIndexChanged += new System.EventHandler(this.ComboBox_ListOfGames_SelectedIndexChanged);
             // 
@@ -1068,5 +1082,6 @@ namespace LiveSplit.MemoryGraph
         private System.Windows.Forms.CheckBox localMaxCB;
         private System.Windows.Forms.Button btnAddColor;
         private System.Windows.Forms.Button btnDeleteColor;
+        private System.Windows.Forms.ComboBox ComboBox_GameVersion;
     }
 }

--- a/Settings.Designer.cs
+++ b/Settings.Designer.cs
@@ -48,7 +48,7 @@ namespace LiveSplit.MemoryGraph
             this.cmbUnitsUsed = new System.Windows.Forms.ComboBox();
             this.unitConversionCB = new System.Windows.Forms.CheckBox();
             this.grpPointerPath = new System.Windows.Forms.GroupBox();
-            this.ComboBox_GameVersion = new System.Windows.Forms.ComboBox();
+            this.ComboBox_GameOption = new System.Windows.Forms.ComboBox();
             this.L_Requires = new System.Windows.Forms.Label();
             this.linkLabel_AdditionalFiles = new System.Windows.Forms.LinkLabel();
             this.ComboBox_ListOfGames = new System.Windows.Forms.ComboBox();
@@ -273,7 +273,7 @@ namespace LiveSplit.MemoryGraph
             // 
             this.grpPointerPath.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.grpPointerPath.Controls.Add(this.ComboBox_GameVersion);
+            this.grpPointerPath.Controls.Add(this.ComboBox_GameOption);
             this.grpPointerPath.Controls.Add(this.L_Requires);
             this.grpPointerPath.Controls.Add(this.linkLabel_AdditionalFiles);
             this.grpPointerPath.Controls.Add(this.ComboBox_ListOfGames);
@@ -291,17 +291,17 @@ namespace LiveSplit.MemoryGraph
             this.grpPointerPath.TabStop = false;
             this.grpPointerPath.Text = "Pointer path";
             // 
-            // ComboBox_GameVersion
+            // ComboBox_GameOption
             // 
-            this.ComboBox_GameVersion.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.ComboBox_GameOption.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.ComboBox_GameVersion.FormattingEnabled = true;
-            this.ComboBox_GameVersion.Location = new System.Drawing.Point(330, 18);
-            this.ComboBox_GameVersion.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.ComboBox_GameVersion.Name = "ComboBox_GameVersion";
-            this.ComboBox_GameVersion.Size = new System.Drawing.Size(100, 21);
-            this.ComboBox_GameVersion.TabIndex = 12;
-            this.ComboBox_GameVersion.SelectedIndexChanged += new System.EventHandler(this.ComboBox_ListOfGames_SelectedIndexChanged);
+            this.ComboBox_GameOption.FormattingEnabled = true;
+            this.ComboBox_GameOption.Location = new System.Drawing.Point(330, 18);
+            this.ComboBox_GameOption.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.ComboBox_GameOption.Name = "ComboBox_GameOption";
+            this.ComboBox_GameOption.Size = new System.Drawing.Size(100, 21);
+            this.ComboBox_GameOption.TabIndex = 12;
+            this.ComboBox_GameOption.SelectedIndexChanged += new System.EventHandler(this.ComboBox_ListOfGames_SelectedIndexChanged);
             // 
             // L_Requires
             // 
@@ -1082,6 +1082,6 @@ namespace LiveSplit.MemoryGraph
         private System.Windows.Forms.CheckBox localMaxCB;
         private System.Windows.Forms.Button btnAddColor;
         private System.Windows.Forms.Button btnDeleteColor;
-        private System.Windows.Forms.ComboBox ComboBox_GameVersion;
+        private System.Windows.Forms.ComboBox ComboBox_GameOption;
     }
 }

--- a/Settings.cs
+++ b/Settings.cs
@@ -658,8 +658,8 @@ namespace LiveSplit.MemoryGraph
                     string name = gameNode.Attributes[0].Value;
                     if (name == (string)ComboBox_ListOfGames.SelectedValue)
                     {
-                        txtProcessName.Text = GetSafeStringValueFromXML(gameNode, "process");
                         ProcessName = GetSafeStringValueFromXML(gameNode, "process");
+                        txtProcessName.Text = ProcessName;
                         AdditionalRequirement = GetSafeStringValueFromXML(gameNode, "additional_requirement_url");
 
                         txtModule.Text = GetSafeStringValueFromXML(gameNode, "module");
@@ -669,6 +669,32 @@ namespace LiveSplit.MemoryGraph
                         txtMaximumValue.Text = GetSafeStringValueFromXML(gameNode, "maximumValue");
                         numValueTextDecimals.Value = GetSafeUIntFromXML(gameNode, "decimals");
                         tbMeterToGameUnit.Text = GetSafeStringValueFromXML(gameNode, "unitConverter");
+
+                        var versions = gameNode.SelectSingleNode("versions");
+                        if (versions != null)
+                        {
+                            // Update the versions drop down to include the verisons.
+                            var versionNames = new List<string>();
+                            foreach (XmlNode versionNode in versions.ChildNodes)
+                            {
+                                versionNames.Add(versionNode.Attributes[0].Value);
+                            }
+                            var prevSource = ComboBox_GameVersion.DataSource as List<string>;
+                            if (prevSource == null || !prevSource.SequenceEqual(versionNames))
+                            {
+                                ComboBox_GameVersion.DataSource = versionNames;
+                            }
+                            ComboBox_GameVersion.Enabled = versionNames.Any();
+
+                            foreach (XmlNode versionNode in versions.ChildNodes)
+                            {
+                                var versionName = versionNode.Attributes[0].Value;
+                                if (versionName == (string)ComboBox_GameVersion.SelectedValue)
+                                {
+                                    // TODO: Parse values, but only the valid ones.
+                                }
+                            }
+                        }
 
                         break;
                     }

--- a/Settings.cs
+++ b/Settings.cs
@@ -490,7 +490,7 @@ namespace LiveSplit.MemoryGraph
             SettingsHelper.CreateSetting(document, parent, "LocalMax", LocalMax) ^
             SettingsHelper.CreateSetting(document, parent, "ProcessName", ProcessName) ^
             SettingsHelper.CreateSetting(document, parent, "DescriptiveText", DescriptiveText) ^
-            
+
             SettingsHelper.CreateSetting(document, parent, "SelectedGame", ComboBox_ListOfGames.SelectedValue) ^
             SettingsHelper.CreateSetting(document, parent, "SelectedGameOption", ComboBox_GameOption.SelectedValue) ^
 
@@ -671,6 +671,8 @@ namespace LiveSplit.MemoryGraph
         {
             if ((string)ComboBox_ListOfGames.SelectedValue == "-None-")
             {
+                ComboBox_GameOption.DataSource = null;
+                ComboBox_GameOption.Enabled = false;
             }
             else
             {
@@ -707,7 +709,7 @@ namespace LiveSplit.MemoryGraph
                             {
                                 ComboBox_GameOption.DataSource = optionNames;
                             }
-                            ComboBox_GameOption.Enabled = optionNames.Any();
+                            ComboBox_GameOption.Enabled = true;
 
                             foreach (XmlNode optionNode in options.ChildNodes)
                             {
@@ -729,6 +731,11 @@ namespace LiveSplit.MemoryGraph
                                     tbMeterToGameUnit.Text = GetSafeStringValueFromXML(optionNode, "unitConverter", tbMeterToGameUnit.Text);
                                 }
                             }
+                        }
+                        else
+                        {
+                            ComboBox_GameOption.DataSource = null;
+                            ComboBox_GameOption.Enabled = false;
                         }
 
                         break;

--- a/Settings.cs
+++ b/Settings.cs
@@ -105,6 +105,22 @@ namespace LiveSplit.MemoryGraph
         List<string> gamesOnTheList = new List<string>();
         static string componentsFolder = "Components";
         public static string listsFile = "LiveSplit.MemoryGraph.Games.xml";
+        public static string ListsFilePath
+        {
+            get
+            {
+                var listsFilePath = Path.Combine(componentsFolder, listsFile);
+                if (File.Exists(listsFilePath))
+                {
+                    return listsFilePath;
+                }
+                else
+                {
+                    // If the new file hasn't been downloaded, keep using the old one as a fallback.
+                    return Path.Combine(componentsFolder, "LiveSplit.MemoryGraphList.xml");
+                }
+            }
+        }
 
         public Color BackgroundColor { get; set; }
         public Color BackgroundColor2 { get; set; }
@@ -156,7 +172,7 @@ namespace LiveSplit.MemoryGraph
         {
             InitializeComponent();
 
-            if (File.Exists(Path.Combine(componentsFolder, listsFile)))
+            if (File.Exists(ListsFilePath))
             {
                 loadXML();
             }
@@ -655,7 +671,7 @@ namespace LiveSplit.MemoryGraph
             ComboBox_ListOfGames.DataSource = null;
             gamesOnTheList.Clear();
             XmlDocument XmlGames = new XmlDocument();
-            XmlGames.Load(Path.Combine(componentsFolder, listsFile));
+            XmlGames.Load(ListsFilePath);
             gamesOnTheList.Add("-None-");
             foreach (XmlNode gameNode in XmlGames.DocumentElement)
             {
@@ -677,7 +693,7 @@ namespace LiveSplit.MemoryGraph
             else
             {
                 XmlDocument XmlGames = new XmlDocument();
-                XmlGames.Load(Path.Combine(componentsFolder, listsFile));
+                XmlGames.Load(ListsFilePath);
                 foreach (XmlNode gameNode in XmlGames.DocumentElement)
                 {
                     string name = gameNode.Attributes[0].Value;

--- a/Settings.cs
+++ b/Settings.cs
@@ -666,45 +666,44 @@ namespace LiveSplit.MemoryGraph
                         txtBase.Text = GetSafeStringValueFromXML(gameNode, "base");
                         txtOffsets.Text = GetSafeStringValueFromXML(gameNode, "offsets");
                         cmbType.SelectedIndex = GetSafeTypeFromXML(gameNode, "type");
-                        txtMaximumValue.Text = GetSafeStringValueFromXML(gameNode, "maximumValue");
+                        txtMaximumValue.Text = GetSafeStringValueFromXML(gameNode, "maximumValue", txtMaximumValue.Text);
                         numValueTextDecimals.Value = GetSafeDecimalFromXML(gameNode, "decimals");
                         tbMeterToGameUnit.Text = GetSafeStringValueFromXML(gameNode, "unitConverter");
 
-                        var versions = gameNode.SelectSingleNode("versions");
-                        if (versions != null)
+                        var options = gameNode.SelectSingleNode("options");
+                        if (options != null)
                         {
-                            // Update the versions drop down to include the verisons.
-                            var versionNames = new List<string>();
-                            foreach (XmlNode versionNode in versions.ChildNodes)
+                            // Update the options drop down to include the verisons.
+                            var optionNames = new List<string>();
+                            foreach (XmlNode optionNode in options.ChildNodes)
                             {
-                                versionNames.Add(versionNode.Attributes[0].Value);
+                                optionNames.Add(optionNode.Attributes[0].Value);
                             }
-                            var prevSource = ComboBox_GameVersion.DataSource as List<string>;
-                            if (prevSource == null || !prevSource.SequenceEqual(versionNames))
+                            var prevSource = ComboBox_GameOption.DataSource as List<string>;
+                            if (prevSource == null || !prevSource.SequenceEqual(optionNames))
                             {
-                                ComboBox_GameVersion.DataSource = versionNames;
+                                ComboBox_GameOption.DataSource = optionNames;
                             }
-                            ComboBox_GameVersion.Enabled = versionNames.Any();
+                            ComboBox_GameOption.Enabled = optionNames.Any();
 
-                            foreach (XmlNode versionNode in versions.ChildNodes)
+                            foreach (XmlNode optionNode in options.ChildNodes)
                             {
-                                var versionName = versionNode.Attributes[0].Value;
-                                if (versionName == (string)ComboBox_GameVersion.SelectedValue)
+                                if (optionNode.Attributes[0].Value == (string)ComboBox_GameOption.SelectedValue)
                                 {
-                                    ProcessName = GetSafeStringValueFromXML(versionNode, "process", ProcessName);
+                                    ProcessName = GetSafeStringValueFromXML(optionNode, "process", ProcessName);
                                     txtProcessName.Text = ProcessName;
-                                    AdditionalRequirement = GetSafeStringValueFromXML(versionNode, "additional_requirement_url", AdditionalRequirement);
+                                    AdditionalRequirement = GetSafeStringValueFromXML(optionNode, "additional_requirement_url", AdditionalRequirement);
 
-                                    txtModule.Text = GetSafeStringValueFromXML(versionNode, "module", txtModule.Text);
-                                    txtBase.Text = GetSafeStringValueFromXML(versionNode, "base", txtBase.Text);
-                                    txtOffsets.Text = GetSafeStringValueFromXML(versionNode, "offsets", txtOffsets.Text);
-                                    if (versionNode.SelectSingleNode("type") != null)
+                                    txtModule.Text = GetSafeStringValueFromXML(optionNode, "module", txtModule.Text);
+                                    txtBase.Text = GetSafeStringValueFromXML(optionNode, "base", txtBase.Text);
+                                    txtOffsets.Text = GetSafeStringValueFromXML(optionNode, "offsets", txtOffsets.Text);
+                                    if (optionNode.SelectSingleNode("type") != null)
                                     {
-                                        cmbType.SelectedIndex = GetSafeTypeFromXML(versionNode, "type");
+                                        cmbType.SelectedIndex = GetSafeTypeFromXML(optionNode, "type");
                                     }
-                                    txtMaximumValue.Text = GetSafeStringValueFromXML(versionNode, "maximumValue", txtMaximumValue.Text);
-                                    numValueTextDecimals.Value = GetSafeDecimalFromXML(versionNode, "decimals", numValueTextDecimals.Value);
-                                    tbMeterToGameUnit.Text = GetSafeStringValueFromXML(versionNode, "unitConverter", tbMeterToGameUnit.Text);
+                                    txtMaximumValue.Text = GetSafeStringValueFromXML(optionNode, "maximumValue", txtMaximumValue.Text);
+                                    numValueTextDecimals.Value = GetSafeDecimalFromXML(optionNode, "decimals", numValueTextDecimals.Value);
+                                    tbMeterToGameUnit.Text = GetSafeStringValueFromXML(optionNode, "unitConverter", tbMeterToGameUnit.Text);
                                 }
                             }
                         }

--- a/Settings.cs
+++ b/Settings.cs
@@ -380,6 +380,26 @@ namespace LiveSplit.MemoryGraph
             ProcessName = SettingsHelper.ParseString(element["ProcessName"]);
             DescriptiveText = SettingsHelper.ParseString(element["DescriptiveText"]);
 
+            var selectedGame = SettingsHelper.ParseString(element["SelectedGame"]);
+            if (selectedGame != null)
+            {
+                var games = ComboBox_ListOfGames.DataSource as List<string>;
+                if (games != null && games.Contains(selectedGame))
+                {
+                    ComboBox_ListOfGames.SelectedItem = selectedGame;
+
+                    var selectedOption = SettingsHelper.ParseString(element["SelectedGameOption"]);
+                    if (selectedOption != null)
+                    {
+                        var options = ComboBox_GameOption.DataSource as List<string>;
+                        if (options != null && options.Contains(selectedOption))
+                        {
+                            ComboBox_GameOption.SelectedItem = selectedOption;
+                        }
+                    }
+                }
+            }
+
             txtModule.Text = SettingsHelper.ParseString(element["Module"]);
             txtBase.Text = SettingsHelper.ParseString(element["Base"]);
             txtOffsets.Text = SettingsHelper.ParseString(element["Offsets"]);
@@ -470,6 +490,9 @@ namespace LiveSplit.MemoryGraph
             SettingsHelper.CreateSetting(document, parent, "LocalMax", LocalMax) ^
             SettingsHelper.CreateSetting(document, parent, "ProcessName", ProcessName) ^
             SettingsHelper.CreateSetting(document, parent, "DescriptiveText", DescriptiveText) ^
+            
+            SettingsHelper.CreateSetting(document, parent, "SelectedGame", ComboBox_ListOfGames.SelectedValue) ^
+            SettingsHelper.CreateSetting(document, parent, "SelectedGameOption", ComboBox_GameOption.SelectedValue) ^
 
             SettingsHelper.CreateSetting(document, parent, "Module", txtModule.Text) ^
             SettingsHelper.CreateSetting(document, parent, "Base", txtBase.Text) ^

--- a/Settings.cs
+++ b/Settings.cs
@@ -104,7 +104,7 @@ namespace LiveSplit.MemoryGraph
         CultureInfo ci = new CultureInfo(System.Threading.Thread.CurrentThread.CurrentCulture.Name);
         List<string> gamesOnTheList = new List<string>();
         static string componentsFolder = "Components";
-        static string listsFile = "LiveSplit.MemoryGraphList.xml";
+        static string listsFile = "LiveSplit.MemoryGraph.Games.xml";
 
         public Color BackgroundColor { get; set; }
         public Color BackgroundColor2 { get; set; }

--- a/Settings.cs
+++ b/Settings.cs
@@ -104,7 +104,7 @@ namespace LiveSplit.MemoryGraph
         CultureInfo ci = new CultureInfo(System.Threading.Thread.CurrentThread.CurrentCulture.Name);
         List<string> gamesOnTheList = new List<string>();
         static string componentsFolder = "Components";
-        static string listsFile = "LiveSplit.MemoryGraph.Games.xml";
+        public static string listsFile = "LiveSplit.MemoryGraph.Games.xml";
 
         public Color BackgroundColor { get; set; }
         public Color BackgroundColor2 { get; set; }

--- a/Settings.cs
+++ b/Settings.cs
@@ -667,7 +667,7 @@ namespace LiveSplit.MemoryGraph
                         txtOffsets.Text = GetSafeStringValueFromXML(gameNode, "offsets");
                         cmbType.SelectedIndex = GetSafeTypeFromXML(gameNode, "type");
                         txtMaximumValue.Text = GetSafeStringValueFromXML(gameNode, "maximumValue");
-                        numValueTextDecimals.Value = GetSafeUIntFromXML(gameNode, "decimals");
+                        numValueTextDecimals.Value = GetSafeDecimalFromXML(gameNode, "decimals");
                         tbMeterToGameUnit.Text = GetSafeStringValueFromXML(gameNode, "unitConverter");
 
                         var versions = gameNode.SelectSingleNode("versions");
@@ -691,7 +691,20 @@ namespace LiveSplit.MemoryGraph
                                 var versionName = versionNode.Attributes[0].Value;
                                 if (versionName == (string)ComboBox_GameVersion.SelectedValue)
                                 {
-                                    // TODO: Parse values, but only the valid ones.
+                                    ProcessName = GetSafeStringValueFromXML(versionNode, "process", ProcessName);
+                                    txtProcessName.Text = ProcessName;
+                                    AdditionalRequirement = GetSafeStringValueFromXML(versionNode, "additional_requirement_url", AdditionalRequirement);
+
+                                    txtModule.Text = GetSafeStringValueFromXML(versionNode, "module", txtModule.Text);
+                                    txtBase.Text = GetSafeStringValueFromXML(versionNode, "base", txtBase.Text);
+                                    txtOffsets.Text = GetSafeStringValueFromXML(versionNode, "offsets", txtOffsets.Text);
+                                    if (versionNode.SelectSingleNode("type") != null)
+                                    {
+                                        cmbType.SelectedIndex = GetSafeTypeFromXML(versionNode, "type");
+                                    }
+                                    txtMaximumValue.Text = GetSafeStringValueFromXML(versionNode, "maximumValue", txtMaximumValue.Text);
+                                    numValueTextDecimals.Value = GetSafeDecimalFromXML(versionNode, "decimals", numValueTextDecimals.Value);
+                                    tbMeterToGameUnit.Text = GetSafeStringValueFromXML(versionNode, "unitConverter", tbMeterToGameUnit.Text);
                                 }
                             }
                         }
@@ -712,14 +725,14 @@ namespace LiveSplit.MemoryGraph
         }
 
         #region GetSafeValuesFunctions
-        private string GetSafeStringValueFromXML(XmlNode docNode, string nodeName)
+        private string GetSafeStringValueFromXML(XmlNode docNode, string nodeName, string defaultValue = "")
         {
             if (docNode.SelectSingleNode(nodeName) != null)
             {
                 return docNode.SelectSingleNode(nodeName).InnerText;
             }
             else
-                return "";
+                return defaultValue;
         }
 
         private int GetSafeTypeFromXML(XmlNode docNode, string nodeName)
@@ -765,20 +778,20 @@ namespace LiveSplit.MemoryGraph
             return (int)MemoryType.Float;
         }
 
-        private uint GetSafeUIntFromXML(XmlNode docNode, string nodeName)
+        private decimal GetSafeDecimalFromXML(XmlNode docNode, string nodeName, decimal defaultValue = 0m)
         {
             if (docNode.SelectSingleNode(nodeName) != null)
             {
                 string text = docNode.SelectSingleNode(nodeName).InnerText;
-                uint value;
-                if (uint.TryParse(text, out value))
+                decimal value;
+                if (decimal.TryParse(text, out value))
                 {
                     return value;
                 }
                 else
-                    return 0;
+                    return defaultValue;
             }
-            return 0;
+            return defaultValue;
         }
         #endregion
 

--- a/XML/LiveSplit.MemoryGraph.Games.xml
+++ b/XML/LiveSplit.MemoryGraph.Games.xml
@@ -2,6 +2,7 @@
 <!--
 <game name="Common name of the game">
 	<process>The process which has the variable needed.</process>
+	<additional_requirement_url>The process which has the variable needed.</additional_requirement_url>
 	<module>The dll which has the variable needed.</module>
 	<base>The base address which points to the variable.</base>
 	<offsets>The offset for the pointer.</offsets>

--- a/XML/LiveSplit.MemoryGraph.Games.xml
+++ b/XML/LiveSplit.MemoryGraph.Games.xml
@@ -1,26 +1,42 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!--
+<game name="Common name of the game">
+	<process>The process which has the variable needed.</process>
+	<module>The dll which has the variable needed.</module>
+	<base>The base address which points to the variable.</base>
+	<offsets>The offset for the pointer.</offsets>
+	<type>The structure used to store the value in game.</type>
+	<maximumValue>The maximum value the variable can be.</maximumValue>
+	<decimals>The number of decimal places needed to express the variable. Defaults to 0.</decimals>
+	<unitConverter>The number of game units in a meter.</unitConverter>
+	Options articulate when there's difference in a game that might need to be switched regularly. This is often a version. Options override the values provided above. An option must always be selected if any are available.
+	<options>
+		<option name="Option name 1">
+			Any of the above tags are valid here.
+		</option>
+		<option name="Option name 2">
+			Any of the above tags are valid here.
+		</option>
+	</options>
+</game>
+-->
 <games>
 <game name="Arabian Nights (3dfx)">
 	<process>_st_3dfx</process>
-	<module></module>
 	<base>9CCD8</base>
 	<offsets>460,490</offsets>
 	<type>IntVec3</type>
 	<maximumValue>2200</maximumValue>
-	<decimals>0</decimals>
 </game>
 <game name="Deus Ex: Human Revolution">
 	<process>dxhr</process>
-	<module></module>
 	<base>14DFA90</base>
-	<offsets></offsets>
 	<type>FloatVec2</type>
 	<maximumValue>50</maximumValue>
 	<decimals>1</decimals>
 </game>
 <game name="Crysis 2">
 	<process>Crysis2</process>
-	<module></module>
 	<base>01770484</base>
 	<offsets>1b8,28,EC</offsets>
 	<type>FloatVec2</type>
@@ -29,7 +45,6 @@
 </game>
 <game name="DUSK">
 	<process>DUSK</process>
-	<module></module>
 	<base>10B8660</base>
 	<offsets>780,50,78</offsets>
 	<type>FloatVec2XZY</type>
@@ -41,7 +56,6 @@
 	<module>ElMatadorGraphWrapper.dll</module>
 	<additional_requirement_url>https://github.com/SuiMachine/LiveSplit.ElMatador</additional_requirement_url>
 	<base>3024</base>
-	<offsets></offsets>
 	<type>FloatVec3</type>
 	<maximumValue>400</maximumValue>
 	<decimals>1</decimals>
@@ -49,9 +63,7 @@
 </game>
 <game name="Hellforces">
 	<process>hell</process>
-	<module></module>
 	<base>11E0D2C</base>
-	<offsets></offsets>
 	<type>FloatVec3</type>
 	<maximumValue>100</maximumValue>
 	<decimals>1</decimals>
@@ -59,25 +71,22 @@
 </game>
 <game name="Hitman: Absolution">
 	<process>HMA</process>
-	<module></module>
 	<base>00D4E510</base>
 	<offsets>80,1A0</offsets>
 	<type>Float</type>
 </game>
 <game name="Judge Dredd: Dredd vs. Death">
 	<process>Dredd</process>
-	<module></module>
 	<base>0023BE80</base>
 	<offsets>0,90,50,58</offsets>
 	<type>Float</type>
 	<maximumValue>120</maximumValue>
-	<decimals>0</decimals>
 </game>
 <game name="Left 4 Dead">
 	<process>left4dead</process>
 	<module>client.dll</module>
-	<offsets></offsets>
 	<type>FloatVec2</type>
+	<unitConverter>52.493438320209973753280839895013</unitConverter>
 	<options>
 		<option name="V1.0">
 			<base>4F0478</base>
@@ -90,8 +99,8 @@
 <game name="Left 4 Dead 2">
 	<process>left4dead2</process>
 	<module>client.dll</module>
-	<offsets></offsets>
 	<type>FloatVec2</type>
+	<unitConverter>52.493438320209973753280839895013</unitConverter>
 	<options>
 		<option name="v2.0.0.0">
 			<base>626588</base>
@@ -119,10 +128,8 @@
 <game name="OpenJK-Speed (no mounts)">
 	<process>openjk_sp.x86</process>
 	<base>407B00</base>
-	<offsets></offsets>
 	<type>FloatVec2</type>
 	<maximumValue>800</maximumValue>
-	<decimals>0</decimals>
 </game>
 <game name="Portal 2">
 	<process>portal2</process>
@@ -131,6 +138,7 @@
 	<offsets>100</offsets>
 	<type>FloatVec2</type>
 	<maximumValue>500</maximumValue>
+	<unitConverter>52.493438320209973753280839895013</unitConverter>
 	<options>
 		<option name="Single Player">
 			<base>09C4B24</base>
@@ -146,13 +154,11 @@
 <game name="Quake (JoeQuake)">
 	<process>joequake-gl</process>
 	<base>64F608</base>
-	<offsets></offsets>
 	<type>FloatVec2</type>
 	<maximumValue>800</maximumValue>
 </game>
 <game name="Quake II">
 	<process>q2pro</process>
-	<offsets></offsets>
 	<type>FloatVec2</type>
 	<maximumValue>800</maximumValue>
 	<options>
@@ -175,15 +181,12 @@
 	<process>SinEpisodes</process>
 	<module>server.dll</module>
 	<base>527C20</base>
-	<offsets></offsets>
 	<type>FloatVec2</type>
 	<maximumValue>350</maximumValue>
-	<decimals>0</decimals>
 </game>
 <game name="Star Trek: Voyager Elite Force">
 	<process>stvoy</process>
 	<base>C6C60</base>
-	<offsets></offsets>
 	<type>FloatVec2</type>
 	<maximumValue>600</maximumValue>
 	<unitConverter>45.00</unitConverter>
@@ -206,10 +209,8 @@
 		</option>
 		<option name="vectors, no mounts">
 			<base>43FD48</base>
-			<offsets></offsets>
 			<type>FloatVec2</type>
 			<maximumValue>800</maximumValue>
-			<decimals>0</decimals>
 		</option>
 	</options>
 </game>
@@ -229,16 +230,13 @@
 </game>
 <game name="The Elder Scrolls V: Skyrim">
 	<process>TESV</process>
-	<module></module>
 	<base>00ED3DE4</base>
 	<offsets>148</offsets>
 	<type>FloatVec3</type>
 	<maximumValue>1000</maximumValue>
-	<decimals>0</decimals>
 </game>
 <game name="Thief 2: The Metal Age (NewDark 1.24)">
 	<process>thief2</process>
-	<module></module>
 	<base>4C8528</base>
 	<offsets>128</offsets>
 	<type>FloatVec2</type>
@@ -247,12 +245,10 @@
 </game>
 <game name="Valley">
 	<process>Valley</process>
-	<module></module>
 	<base>128D940</base>
 	<offsets>918,18,0,840,C4</offsets>
 	<type>FloatVec2XZY</type>
 	<maximumValue>50</maximumValue>
-	<decimals>0</decimals>
 </game>
 <game name="Wheel of Time">
 	<process>WoT</process>
@@ -261,11 +257,9 @@
 	<offsets>80, 30, 100</offsets>
 	<type>FloatVec3</type>
 	<maximumValue>1000</maximumValue>
-	<decimals>0</decimals>
 </game>
 <game name="Wrack">
 	<process>Wrack_steam</process>
-	<module></module>
 	<base>1A001C</base>
 	<offsets>595</offsets>
 	<type>FloatVec3</type>

--- a/XML/LiveSplit.MemoryGraph.Games.xml
+++ b/XML/LiveSplit.MemoryGraph.Games.xml
@@ -22,244 +22,252 @@
 </game>
 -->
 <games>
-<game name="Arabian Nights (3dfx)">
-	<process>_st_3dfx</process>
-	<base>9CCD8</base>
-	<offsets>460,490</offsets>
-	<type>IntVec3</type>
-	<maximumValue>2200</maximumValue>
-</game>
-<game name="Deus Ex: Human Revolution">
-	<process>dxhr</process>
-	<base>14DFA90</base>
-	<type>FloatVec2</type>
-	<maximumValue>50</maximumValue>
-	<decimals>1</decimals>
-</game>
-<game name="Crysis 2">
-	<process>Crysis2</process>
-	<base>01770484</base>
-	<offsets>1b8,28,EC</offsets>
-	<type>FloatVec2</type>
-	<maximumValue>20</maximumValue>
-	<decimals>2</decimals>
-</game>
-<game name="DUSK">
-	<process>DUSK</process>
-	<base>10B8660</base>
-	<offsets>780,50,78</offsets>
-	<type>FloatVec2XZY</type>
-	<maximumValue>50</maximumValue>
-	<decimals>2</decimals>
-</game>
-<game name="El Matador (dll injection required)">
-	<process>pc_matador</process>
-	<module>ElMatadorGraphWrapper.dll</module>
-	<additional_requirement_url>https://github.com/SuiMachine/LiveSplit.ElMatador</additional_requirement_url>
-	<base>3024</base>
-	<type>FloatVec3</type>
-	<maximumValue>400</maximumValue>
-	<decimals>1</decimals>
-	<unitConverter>12.22</unitConverter>
-</game>
-<game name="Hellforces">
-	<process>hell</process>
-	<base>11E0D2C</base>
-	<type>FloatVec3</type>
-	<maximumValue>100</maximumValue>
-	<decimals>1</decimals>
-	<unitConverter>1.62</unitConverter>
-</game>
-<game name="Hitman: Absolution">
-	<process>HMA</process>
-	<base>00D4E510</base>
-	<offsets>80,1A0</offsets>
-	<type>Float</type>
-</game>
-<game name="Judge Dredd: Dredd vs. Death">
-	<process>Dredd</process>
-	<base>0023BE80</base>
-	<offsets>0,90,50,58</offsets>
-	<type>Float</type>
-	<maximumValue>120</maximumValue>
-</game>
-<game name="Left 4 Dead">
-	<process>left4dead</process>
-	<module>client.dll</module>
-	<type>FloatVec2</type>
-	<unitConverter>52.49344</unitConverter>
-	<options>
-		<option name="1.0">
-			<base>4F0478</base>
-		</option>
-		<option name="Newest">
-			<base>512208</base>
-		</option>
-	</options>
-</game>
-<game name="Left 4 Dead 2">
-	<process>left4dead2</process>
-	<module>client.dll</module>
-	<type>FloatVec2</type>
-	<unitConverter>52.49344</unitConverter>
-	<options>
-		<option name="2.0.0.0">
-			<base>626588</base>
-		</option>
-		<option name="2.0.1.2">
-			<base>62F850</base>
-		</option>
-		<option name="2.0.2.7">
-			<base>62F850</base>
-		</option>
-		<option name="2.0.4.5">
-			<base>63FA28</base>
-		</option>
-		<option name="2.0.7.5">
-			<base>6419F0</base>
-		</option>
-		<option name="2.0.9.1">
-			<base>6419F0</base>
-		</option>
-		<option name="2.1.5.0">
-			<base>6BADC0</base>
-		</option>
-	</options>
-</game>
-<game name="OpenJK-Speed (no mounts)">
-	<process>openjk_sp.x86</process>
-	<base>407B00</base>
-	<type>FloatVec2</type>
-	<maximumValue>800</maximumValue>
-</game>
-<game name="Portal 2">
-	<process>portal2</process>
-	<module>client.dll</module>
-	<offsets>100</offsets>
-	<type>FloatVec2</type>
-	<maximumValue>500</maximumValue>
-	<unitConverter>52.49344</unitConverter>
-	<options>
-		<option name="Chell/Blue">
-			<base>09C4B24</base>
-		</option>
-		<option name="Orange">
-			<base>09C4B2C</base>
-		</option>
-	</options>
-</game>
-<game name="Quake (JoeQuake)">
-	<process>joequake-gl</process>
-	<base>64F608</base>
-	<type>FloatVec2</type>
-	<maximumValue>800</maximumValue>
-</game>
-<game name="Quake II">
-	<process>q2pro</process>
-	<type>FloatVec2</type>
-	<maximumValue>800</maximumValue>
-	<options>
-		<option name="Q2PRO 2014-12-03">
-			<base>15574C</base>
-		</option>
-		<option name="Q2PRO 2016-01-12">
-			<base>15674C</base>
-		</option>
-	</options>
-</game>
-<game name="RBDoom3BFG (1.1.0)">
-	<process>RBDoom3BFG</process>
-	<base>014C93A8</base>
-	<offsets>3C4,98</offsets>
-	<type>FloatVec2</type>
-	<maximumValue>750</maximumValue>
-</game>
-<game name="Sin Episodes: Emergance">
-	<process>SinEpisodes</process>
-	<module>server.dll</module>
-	<base>527C20</base>
-	<type>FloatVec2</type>
-	<maximumValue>350</maximumValue>
-</game>
-<game name="Star Trek: Voyager Elite Force">
-	<process>stvoy</process>
-	<type>FloatVec2</type>
-	<maximumValue>600</maximumValue>
-	<unitConverter>45.00</unitConverter>
-	<options>
-		<option name="v1.1">
-			<base>C6C60</base>
-		</option>
-		<option name="v1.2">
-			<base>BB800</base>
-		</option>
-	</options>
-</game>
-<game name="Star Wars Jedi Knight: Jedi Academy">
-	<process>jasp</process>
-	<options>
-		<option name="Normal">
-			<base>00897B70</base>
-			<offsets>A4,3C</offsets>
-			<type>Float</type>
-		</option>
-		<option name="vectors, no mounts">
-			<base>43FD48</base>
-			<type>FloatVec2</type>
-			<maximumValue>800</maximumValue>
-		</option>
-	</options>
-</game>
-<game name="Star Wars Jedi Knight: Jedi Outcast">
-	<type>FloatVec2</type>
-	<maximumValue>1000</maximumValue>
-	<options>
-		<option name="SP">
-			<process>jk2sp</process>
-			<base>41D4B8</base>
-		</option>
-		<option name="MP">
-			<process>jk2mp</process>
-			<base>4F8F40</base>
-		</option>
-	</options>
-</game>
-<game name="The Elder Scrolls V: Skyrim">
-	<process>TESV</process>
-	<base>00ED3DE4</base>
-	<offsets>148</offsets>
-	<type>FloatVec3</type>
-	<maximumValue>1000</maximumValue>
-</game>
-<game name="Thief 2: The Metal Age (NewDark 1.24)">
-	<process>thief2</process>
-	<base>4C8528</base>
-	<offsets>128</offsets>
-	<type>FloatVec2</type>
-	<maximumValue>40</maximumValue>
-	<decimals>1</decimals>
-</game>
-<game name="Valley">
-	<process>Valley</process>
-	<base>128D940</base>
-	<offsets>918,18,0,840,C4</offsets>
-	<type>FloatVec2XZY</type>
-	<maximumValue>50</maximumValue>
-</game>
-<game name="Wheel of Time">
-	<process>WoT</process>
-	<module>Engine.dll</module>
-	<base>26568C</base>
-	<offsets>80, 30, 100</offsets>
-	<type>FloatVec3</type>
-	<maximumValue>1000</maximumValue>
-</game>
-<game name="Wrack">
-	<process>Wrack_steam</process>
-	<base>1A001C</base>
-	<offsets>595</offsets>
-	<type>FloatVec3</type>
-	<maximumValue>15</maximumValue>
-	<decimals>2</decimals>
-</game>
+	<game name="Arabian Nights (3dfx)">
+		<process>_st_3dfx</process>
+		<base>9CCD8</base>
+		<offsets>460,490</offsets>
+		<type>IntVec3</type>
+		<maximumValue>2200</maximumValue>
+	</game>
+	<game name="Deus Ex: Human Revolution">
+		<process>dxhr</process>
+		<base>14DFA90</base>
+		<type>FloatVec2</type>
+		<maximumValue>50</maximumValue>
+		<decimals>1</decimals>
+	</game>
+	<game name="Crysis 2">
+		<process>Crysis2</process>
+		<base>01770484</base>
+		<offsets>1b8,28,EC</offsets>
+		<type>FloatVec2</type>
+		<maximumValue>20</maximumValue>
+		<decimals>2</decimals>
+	</game>
+	<game name="DUSK">
+		<process>DUSK</process>
+		<base>10B8660</base>
+		<offsets>780,50,78</offsets>
+		<type>FloatVec2XZY</type>
+		<maximumValue>50</maximumValue>
+		<decimals>2</decimals>
+	</game>
+	<game name="El Matador (dll injection required)">
+		<process>pc_matador</process>
+		<module>ElMatadorGraphWrapper.dll</module>
+		<additional_requirement_url>https://github.com/SuiMachine/LiveSplit.ElMatador</additional_requirement_url>
+		<base>3024</base>
+		<type>FloatVec3</type>
+		<maximumValue>400</maximumValue>
+		<decimals>1</decimals>
+		<unitConverter>12.22</unitConverter>
+	</game>
+	<game name="Hellforces">
+		<process>hell</process>
+		<base>11E0D2C</base>
+		<type>FloatVec3</type>
+		<maximumValue>100</maximumValue>
+		<decimals>1</decimals>
+		<unitConverter>1.62</unitConverter>
+	</game>
+	<game name="Hitman: Absolution">
+		<process>HMA</process>
+		<base>00D4E510</base>
+		<offsets>80,1A0</offsets>
+		<type>Float</type>
+	</game>
+	<game name="Judge Dredd: Dredd vs. Death">
+		<process>Dredd</process>
+		<base>0023BE80</base>
+		<offsets>0,90,50,58</offsets>
+		<type>Float</type>
+		<maximumValue>120</maximumValue>
+	</game>
+	<game name="Left 4 Dead">
+		<process>left4dead</process>
+		<module>client.dll</module>
+		<type>FloatVec2</type>
+		<unitConverter>52.49344</unitConverter>
+		<options>
+			<option name="1.0">
+				<base>4F0478</base>
+			</option>
+			<option name="Newest">
+				<base>512208</base>
+			</option>
+		</options>
+	</game>
+	<game name="Left 4 Dead 2">
+		<process>left4dead2</process>
+		<module>client.dll</module>
+		<type>FloatVec2</type>
+		<unitConverter>52.49344</unitConverter>
+		<options>
+			<option name="2.0.0.0">
+				<base>626588</base>
+			</option>
+			<option name="2.0.1.2">
+				<base>62F850</base>
+			</option>
+			<option name="2.0.2.7">
+				<base>62F850</base>
+			</option>
+			<option name="2.0.4.5">
+				<base>63FA28</base>
+			</option>
+			<option name="2.0.7.5">
+				<base>6419F0</base>
+			</option>
+			<option name="2.0.9.1">
+				<base>6419F0</base>
+			</option>
+			<option name="2.1.5.0">
+				<base>6BADC0</base>
+			</option>
+		</options>
+	</game>
+	<game name="Mirror's Edge Catalyst">
+		<process>MirrorsEdgeCatalyst</process>
+		<base>23E29B8</base>
+		<offsets>2378, 10, 438</offsets>
+		<type>FloatVec2</type>
+		<maximumValue>20</maximumValue>
+		<decimals>2</decimals>
+	</game>
+	<game name="OpenJK-Speed (no mounts)">
+		<process>openjk_sp.x86</process>
+		<base>407B00</base>
+		<type>FloatVec2</type>
+		<maximumValue>800</maximumValue>
+	</game>
+	<game name="Portal 2">
+		<process>portal2</process>
+		<module>client.dll</module>
+		<offsets>100</offsets>
+		<type>FloatVec2</type>
+		<maximumValue>500</maximumValue>
+		<unitConverter>52.49344</unitConverter>
+		<options>
+			<option name="Chell/Blue">
+				<base>09C4B24</base>
+			</option>
+			<option name="Orange">
+				<base>09C4B2C</base>
+			</option>
+		</options>
+	</game>
+	<game name="Quake (JoeQuake)">
+		<process>joequake-gl</process>
+		<base>64F608</base>
+		<type>FloatVec2</type>
+		<maximumValue>800</maximumValue>
+	</game>
+	<game name="Quake II">
+		<process>q2pro</process>
+		<type>FloatVec2</type>
+		<maximumValue>800</maximumValue>
+		<options>
+			<option name="Q2PRO 2014-12-03">
+				<base>15574C</base>
+			</option>
+			<option name="Q2PRO 2016-01-12">
+				<base>15674C</base>
+			</option>
+		</options>
+	</game>
+	<game name="RBDoom3BFG (1.1.0)">
+		<process>RBDoom3BFG</process>
+		<base>014C93A8</base>
+		<offsets>3C4,98</offsets>
+		<type>FloatVec2</type>
+		<maximumValue>750</maximumValue>
+	</game>
+	<game name="Sin Episodes: Emergance">
+		<process>SinEpisodes</process>
+		<module>server.dll</module>
+		<base>527C20</base>
+		<type>FloatVec2</type>
+		<maximumValue>350</maximumValue>
+	</game>
+	<game name="Star Trek: Voyager Elite Force">
+		<process>stvoy</process>
+		<type>FloatVec2</type>
+		<maximumValue>600</maximumValue>
+		<unitConverter>45.00</unitConverter>
+		<options>
+			<option name="v1.1">
+				<base>C6C60</base>
+			</option>
+			<option name="v1.2">
+				<base>BB800</base>
+			</option>
+		</options>
+	</game>
+	<game name="Star Wars Jedi Knight: Jedi Academy">
+		<process>jasp</process>
+		<options>
+			<option name="Normal">
+				<base>00897B70</base>
+				<offsets>A4,3C</offsets>
+				<type>Float</type>
+			</option>
+			<option name="vectors, no mounts">
+				<base>43FD48</base>
+				<type>FloatVec2</type>
+				<maximumValue>800</maximumValue>
+			</option>
+		</options>
+	</game>
+	<game name="Star Wars Jedi Knight: Jedi Outcast">
+		<type>FloatVec2</type>
+		<maximumValue>1000</maximumValue>
+		<options>
+			<option name="SP">
+				<process>jk2sp</process>
+				<base>41D4B8</base>
+			</option>
+			<option name="MP">
+				<process>jk2mp</process>
+				<base>4F8F40</base>
+			</option>
+		</options>
+	</game>
+	<game name="The Elder Scrolls V: Skyrim">
+		<process>TESV</process>
+		<base>00ED3DE4</base>
+		<offsets>148</offsets>
+		<type>FloatVec3</type>
+		<maximumValue>1000</maximumValue>
+	</game>
+	<game name="Thief 2: The Metal Age (NewDark 1.24)">
+		<process>thief2</process>
+		<base>4C8528</base>
+		<offsets>128</offsets>
+		<type>FloatVec2</type>
+		<maximumValue>40</maximumValue>
+		<decimals>1</decimals>
+	</game>
+	<game name="Valley">
+		<process>Valley</process>
+		<base>128D940</base>
+		<offsets>918,18,0,840,C4</offsets>
+		<type>FloatVec2XZY</type>
+		<maximumValue>50</maximumValue>
+	</game>
+	<game name="Wheel of Time">
+		<process>WoT</process>
+		<module>Engine.dll</module>
+		<base>26568C</base>
+		<offsets>80, 30, 100</offsets>
+		<type>FloatVec3</type>
+		<maximumValue>1000</maximumValue>
+	</game>
+	<game name="Wrack">
+		<process>Wrack_steam</process>
+		<base>1A001C</base>
+		<offsets>595</offsets>
+		<type>FloatVec3</type>
+		<maximumValue>15</maximumValue>
+		<decimals>2</decimals>
+	</game>
 </games>

--- a/XML/LiveSplit.MemoryGraph.Games.xml
+++ b/XML/LiveSplit.MemoryGraph.Games.xml
@@ -86,12 +86,12 @@
 	<process>left4dead</process>
 	<module>client.dll</module>
 	<type>FloatVec2</type>
-	<unitConverter>52.493438320209973753280839895013</unitConverter>
+	<unitConverter>52.49344</unitConverter>
 	<options>
 		<option name="V1.0">
 			<base>4F0478</base>
 		</option>
-		<option name="Steam option">
+		<option name="Steam Version">
 			<base>512208</base>
 		</option>
 	</options>
@@ -100,7 +100,7 @@
 	<process>left4dead2</process>
 	<module>client.dll</module>
 	<type>FloatVec2</type>
-	<unitConverter>52.493438320209973753280839895013</unitConverter>
+	<unitConverter>52.49344</unitConverter>
 	<options>
 		<option name="v2.0.0.0">
 			<base>626588</base>
@@ -138,7 +138,7 @@
 	<offsets>100</offsets>
 	<type>FloatVec2</type>
 	<maximumValue>500</maximumValue>
-	<unitConverter>52.493438320209973753280839895013</unitConverter>
+	<unitConverter>52.49344</unitConverter>
 	<options>
 		<option name="Single Player">
 			<base>09C4B24</base>

--- a/XML/LiveSplit.MemoryGraph.Games.xml
+++ b/XML/LiveSplit.MemoryGraph.Games.xml
@@ -73,62 +73,48 @@
 	<maximumValue>120</maximumValue>
 	<decimals>0</decimals>
 </game>
-<game name="Left 4 Dead (v1.0)">
+<game name="Left 4 Dead">
 	<process>left4dead</process>
 	<module>client.dll</module>
-	<base>4F0478</base>
 	<offsets></offsets>
 	<type>FloatVec2</type>
+	<options>
+		<option name="V1.0">
+			<base>4F0478</base>
+		</option>
+		<option name="Steam option">
+			<base>512208</base>
+		</option>
+	</options>
 </game>
-<game name="Left 4 Dead (Steam Version)">
-	<process>left4dead</process>
-	<module>client.dll</module>
-	<base>512208</base>
-	<offsets></offsets>
-	<type>FloatVec2</type>
-</game>
-<game name="Left 4 Dead 2 (v2.0.0.0)">
+<game name="Left 4 Dead 2">
 	<process>left4dead2</process>
 	<module>client.dll</module>
-	<base>626588</base>
 	<offsets></offsets>
 	<type>FloatVec2</type>
-</game>
-<game name="Left 4 Dead 2 (v2.0.1.2 and v2.0.2.7)">
-	<process>left4dead2</process>
-	<module>client.dll</module>
-	<base>62F850</base>
-	<offsets></offsets>
-	<type>FloatVec2</type>
-</game>
-<game name="Left 4 Dead 2 (v2.0.4.5)">
-	<process>left4dead2</process>
-	<module>client.dll</module>
-	<base>63FA28</base>
-	<offsets></offsets>
-	<type>FloatVec2</type>
-</game>
-<game name="Left 4 Dead 2 (v2.0.7.5 and v2.0.9.1)">
-	<process>left4dead2</process>
-	<module>client.dll</module>
-	<base>6419F0</base>
-	<offsets></offsets>
-	<type>FloatVec2</type>
-</game>
-<game name="Left 4 Dead 2 (v2.1.5.0)">
-	<process>left4dead2</process>
-	<module>client.dll</module>
-	<base>6BADC0</base>
-	<offsets></offsets>
-	<type>FloatVec2</type>
-</game>
-<game name="Mirror's Edge Catalyst">
-	<process>MirrorsEdgeCatalyst</process>
-	<base>23E29B8</base>
-	<offsets>2378, 10, 438</offsets>
-	<type>FloatVec2</type>
-	<maximumValue>20</maximumValue>
-	<decimals>2</decimals>
+	<options>
+		<option name="v2.0.0.0">
+			<base>626588</base>
+		</option>
+		<option name="v2.0.1.2">
+			<base>62F850</base>
+		</option>
+		<option name="v2.0.2.7">
+			<base>62F850</base>
+		</option>
+		<option name="v2.0.4.5">
+			<base>63FA28</base>
+		</option>
+		<option name="v2.0.7.5">
+			<base>6419F0</base>
+		</option>
+		<option name="v2.0.9.1">
+			<base>6419F0</base>
+		</option>
+		<option name="v2.1.5.0">
+			<base>6BADC0</base>
+		</option>
+	</options>
 </game>
 <game name="OpenJK-Speed (no mounts)">
 	<process>openjk_sp.x86</process>
@@ -138,21 +124,24 @@
 	<maximumValue>800</maximumValue>
 	<decimals>0</decimals>
 </game>
-<game name="Portal 2 (Single Player or Blue)">
+<game name="Portal 2">
 	<process>portal2</process>
 	<module>client.dll</module>
 	<base>09C4B24</base>
 	<offsets>100</offsets>
 	<type>FloatVec2</type>
 	<maximumValue>500</maximumValue>
-</game>
-<game name="Portal 2 (Orange)">
-	<process>portal2</process>
-	<module>client.dll</module>
-	<base>09C4B2C</base>
-	<offsets>100</offsets>
-	<type>FloatVec2</type>
-	<maximumValue>500</maximumValue>
+	<options>
+		<option name="Single Player">
+			<base>09C4B24</base>
+		</option>
+		<option name="Blue">
+			<base>09C4B24</base>
+		</option>
+		<option name="Orange">
+			<base>09C4B2C</base>
+		</option>
+	</options>
 </game>
 <game name="Quake (JoeQuake)">
 	<process>joequake-gl</process>
@@ -161,19 +150,19 @@
 	<type>FloatVec2</type>
 	<maximumValue>800</maximumValue>
 </game>
-<game name="Quake II (Q2PRO 2014-12-03)">
+<game name="Quake II">
 	<process>q2pro</process>
-	<base>15574C</base>
 	<offsets></offsets>
 	<type>FloatVec2</type>
 	<maximumValue>800</maximumValue>
-</game>
-<game name="Quake II (Q2PRO 2016-01-12)">
-	<process>q2pro</process>
-	<base>15674C</base>
-	<offsets></offsets>
-	<type>FloatVec2</type>
-	<maximumValue>800</maximumValue>
+	<options>
+		<option name="Q2PRO 2014-12-03">
+			<base>15574C</base>
+		</option>
+		<option name="Q2PRO 2016-01-12">
+			<base>15674C</base>
+		</option>
+	</options>
 </game>
 <game name="RBDoom3BFG (1.1.0)">
 	<process>RBDoom3BFG</process>
@@ -191,49 +180,52 @@
 	<maximumValue>350</maximumValue>
 	<decimals>0</decimals>
 </game>
-<game name="Star Trek: Voyager Elite Force (v1.1)">
+<game name="Star Trek: Voyager Elite Force">
 	<process>stvoy</process>
 	<base>C6C60</base>
 	<offsets></offsets>
 	<type>FloatVec2</type>
 	<maximumValue>600</maximumValue>
 	<unitConverter>45.00</unitConverter>
-</game>
-<game name="Star Trek: Voyager Elite Force (v1.2)">
-	<process>stvoy</process>
-	<base>BB800</base>
-	<offsets></offsets>
-	<type>FloatVec2</type>
-	<maximumValue>600</maximumValue>
-	<unitConverter>45.00</unitConverter>
+	<options>
+		<option name="v1.1">
+			<base>C6C60</base>
+		</option>
+		<option name="v1.2">
+			<base>BB800</base>
+		</option>
+	</options>
 </game>
 <game name="Star Wars Jedi Knight: Jedi Academy">
 	<process>jasp</process>
-	<base>00897B70</base>
-	<offsets>A4,3C</offsets>
-	<type>Float</type>
+	<options>
+		<option name="Normal">
+			<base>00897B70</base>
+			<offsets>A4,3C</offsets>
+			<type>Float</type>
+		</option>
+		<option name="vectors, no mounts">
+			<base>43FD48</base>
+			<offsets></offsets>
+			<type>FloatVec2</type>
+			<maximumValue>800</maximumValue>
+			<decimals>0</decimals>
+		</option>
+	</options>
 </game>
-<game name="Star Wars Jedi Knight: Jedi Academy (vectors, no mounts)">
-	<process>jasp</process>
-	<base>43FD48</base>
-	<offsets></offsets>
-	<type>FloatVec2</type>
-	<maximumValue>800</maximumValue>
-	<decimals>0</decimals>
-</game>
-<game name="Star Wars Jedi Knight: Jedi Outcast SP">
-	<process>jk2sp</process>
-	<base>41D4B8</base>
-	<offsets></offsets>
-	<type>FloatVec2</type>
-	<maximumValue>1000</maximumValue>
-</game>
-<game name="Star Wars Jedi Knight: Jedi Outcast MP">
-	<process>jk2mp</process>
-	<base>4F8F40</base>
-	<offsets></offsets>
+<game name="Star Wars Jedi Knight: Jedi Outcast">
 	<type>FloatVec2</type>
 	<maximumValue>1000</maximumValue>
+	<options>
+		<option name="SP">
+			<process>jk2sp</process>
+			<base>41D4B8</base>
+		</option>
+		<option name="MP">
+			<process>jk2mp</process>
+			<base>4F8F40</base>
+		</option>
+	</options>
 </game>
 <game name="The Elder Scrolls V: Skyrim">
 	<process>TESV</process>

--- a/XML/LiveSplit.MemoryGraph.Games.xml
+++ b/XML/LiveSplit.MemoryGraph.Games.xml
@@ -2,7 +2,7 @@
 <!--
 <game name="Common name of the game">
 	<process>The process which has the variable needed.</process>
-	<additional_requirement_url>The process which has the variable needed.</additional_requirement_url>
+	<additional_requirement_url>A URL to provide to the user which has additional requirements.</additional_requirement_url>
 	<module>The dll which has the variable needed.</module>
 	<base>The base address which points to the variable.</base>
 	<offsets>The offset for the pointer.</offsets>
@@ -89,10 +89,10 @@
 	<type>FloatVec2</type>
 	<unitConverter>52.49344</unitConverter>
 	<options>
-		<option name="V1.0">
+		<option name="1.0">
 			<base>4F0478</base>
 		</option>
-		<option name="Steam Version">
+		<option name="Newest">
 			<base>512208</base>
 		</option>
 	</options>
@@ -103,25 +103,25 @@
 	<type>FloatVec2</type>
 	<unitConverter>52.49344</unitConverter>
 	<options>
-		<option name="v2.0.0.0">
+		<option name="2.0.0.0">
 			<base>626588</base>
 		</option>
-		<option name="v2.0.1.2">
+		<option name="2.0.1.2">
 			<base>62F850</base>
 		</option>
-		<option name="v2.0.2.7">
+		<option name="2.0.2.7">
 			<base>62F850</base>
 		</option>
-		<option name="v2.0.4.5">
+		<option name="2.0.4.5">
 			<base>63FA28</base>
 		</option>
-		<option name="v2.0.7.5">
+		<option name="2.0.7.5">
 			<base>6419F0</base>
 		</option>
-		<option name="v2.0.9.1">
+		<option name="2.0.9.1">
 			<base>6419F0</base>
 		</option>
-		<option name="v2.1.5.0">
+		<option name="2.1.5.0">
 			<base>6BADC0</base>
 		</option>
 	</options>
@@ -135,16 +135,12 @@
 <game name="Portal 2">
 	<process>portal2</process>
 	<module>client.dll</module>
-	<base>09C4B24</base>
 	<offsets>100</offsets>
 	<type>FloatVec2</type>
 	<maximumValue>500</maximumValue>
 	<unitConverter>52.49344</unitConverter>
 	<options>
-		<option name="Single Player">
-			<base>09C4B24</base>
-		</option>
-		<option name="Blue">
+		<option name="Chell/Blue">
 			<base>09C4B24</base>
 		</option>
 		<option name="Orange">
@@ -187,7 +183,6 @@
 </game>
 <game name="Star Trek: Voyager Elite Force">
 	<process>stvoy</process>
-	<base>C6C60</base>
 	<type>FloatVec2</type>
 	<maximumValue>600</maximumValue>
 	<unitConverter>45.00</unitConverter>

--- a/XML/LiveSplit.MemoryGraphList.xml
+++ b/XML/LiveSplit.MemoryGraphList.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!--
+	Do not add new games to this file! Add them to LiveSplit.MemoryGraph.Games.xml instead.
+-->
 <games>
 <game name="Arabian Nights (3dfx)">
 	<process>_st_3dfx</process>

--- a/XML/LiveSplit.MemoryGraphList.xml
+++ b/XML/LiveSplit.MemoryGraphList.xml
@@ -73,54 +73,42 @@
 	<maximumValue>120</maximumValue>
 	<decimals>0</decimals>
 </game>
-<game name="Left 4 Dead (v1.0)">
+<game name="Left 4 Dead">
 	<process>left4dead</process>
 	<module>client.dll</module>
-	<base>4F0478</base>
 	<offsets></offsets>
 	<type>FloatVec2</type>
+  <versions>
+    <version name="V1.0">
+      <base>4F0478</base>
+    </version>
+    <version name="Steam Version">
+      <base>512208</base>
+    </version>
+  </versions>
 </game>
-<game name="Left 4 Dead (Steam Version)">
-	<process>left4dead</process>
-	<module>client.dll</module>
-	<base>512208</base>
-	<offsets></offsets>
-	<type>FloatVec2</type>
-</game>
-<game name="Left 4 Dead 2 (v2.0.0.0)">
+<game name="Left 4 Dead 2">
 	<process>left4dead2</process>
 	<module>client.dll</module>
-	<base>626588</base>
 	<offsets></offsets>
 	<type>FloatVec2</type>
-</game>
-<game name="Left 4 Dead 2 (v2.0.1.2 and v2.0.2.7)">
-	<process>left4dead2</process>
-	<module>client.dll</module>
-	<base>62F850</base>
-	<offsets></offsets>
-	<type>FloatVec2</type>
-</game>
-<game name="Left 4 Dead 2 (v2.0.4.5)">
-	<process>left4dead2</process>
-	<module>client.dll</module>
-	<base>63FA28</base>
-	<offsets></offsets>
-	<type>FloatVec2</type>
-</game>
-<game name="Left 4 Dead 2 (v2.0.7.5 and v2.0.9.1)">
-	<process>left4dead2</process>
-	<module>client.dll</module>
-	<base>6419F0</base>
-	<offsets></offsets>
-	<type>FloatVec2</type>
-</game>
-<game name="Left 4 Dead 2 (v2.1.5.0)">
-	<process>left4dead2</process>
-	<module>client.dll</module>
-	<base>6BADC0</base>
-	<offsets></offsets>
-	<type>FloatVec2</type>
+  <versions>
+    <version name="v2.0.0.0">
+      <base>626588</base>
+    </version>
+    <version name="v2.0.1.2 and v2.0.2.7">
+      <base>62F850</base>
+    </version>
+    <version name="v2.0.4.5">
+      <base>63FA28</base>
+    </version>
+    <version name="v2.0.7.5 and v2.0.9.1">
+      <base>6419F0</base>
+    </version>
+    <version name="v2.1.5.0">
+      <base>6BADC0</base>
+    </version>
+  </versions>
 </game>
 <game name="Mirror's Edge Catalyst">
 	<process>MirrorsEdgeCatalyst</process>
@@ -161,19 +149,19 @@
 	<type>FloatVec2</type>
 	<maximumValue>800</maximumValue>
 </game>
-<game name="Quake II (Q2PRO 2014-12-03)">
+<game name="Quake II">
 	<process>q2pro</process>
-	<base>15574C</base>
 	<offsets></offsets>
 	<type>FloatVec2</type>
 	<maximumValue>800</maximumValue>
-</game>
-<game name="Quake II (Q2PRO 2016-01-12)">
-	<process>q2pro</process>
-	<base>15674C</base>
-	<offsets></offsets>
-	<type>FloatVec2</type>
-	<maximumValue>800</maximumValue>
+  <versions>
+    <version name="Q2PRO 2014-12-03">
+      <base>15574C</base>
+    </version>
+    <version name="Q2PRO 2016-01-12">
+      <base>15674C</base>
+    </version>
+  </versions>
 </game>
 <game name="RBDoom3BFG (1.1.0)">
 	<process>RBDoom3BFG</process>
@@ -191,21 +179,21 @@
 	<maximumValue>350</maximumValue>
 	<decimals>0</decimals>
 </game>
-<game name="Star Trek: Voyager Elite Force (v1.1)">
+<game name="Star Trek: Voyager Elite Force">
 	<process>stvoy</process>
 	<base>C6C60</base>
 	<offsets></offsets>
 	<type>FloatVec2</type>
 	<maximumValue>600</maximumValue>
 	<unitConverter>45.00</unitConverter>
-</game>
-<game name="Star Trek: Voyager Elite Force (v1.2)">
-	<process>stvoy</process>
-	<base>BB800</base>
-	<offsets></offsets>
-	<type>FloatVec2</type>
-	<maximumValue>600</maximumValue>
-	<unitConverter>45.00</unitConverter>
+  <versions>
+    <version name="v1.1">
+      <base>C6C60</base>
+    </version>
+    <version name="v1.2">
+      <base>BB800</base>
+    </version>
+  </versions>
 </game>
 <game name="Star Wars Jedi Knight: Jedi Academy">
 	<process>jasp</process>

--- a/XML/LiveSplit.MemoryGraphList.xml
+++ b/XML/LiveSplit.MemoryGraphList.xml
@@ -78,37 +78,43 @@
 	<module>client.dll</module>
 	<offsets></offsets>
 	<type>FloatVec2</type>
-  <options>
-    <option name="V1.0">
-      <base>4F0478</base>
-    </option>
-    <option name="Steam option">
-      <base>512208</base>
-    </option>
-  </options>
+	<options>
+		<option name="V1.0">
+			<base>4F0478</base>
+		</option>
+		<option name="Steam option">
+			<base>512208</base>
+		</option>
+	</options>
 </game>
 <game name="Left 4 Dead 2">
 	<process>left4dead2</process>
 	<module>client.dll</module>
 	<offsets></offsets>
 	<type>FloatVec2</type>
-  <options>
-    <option name="v2.0.0.0">
-      <base>626588</base>
-    </option>
-    <option name="v2.0.1.2 and v2.0.2.7">
-      <base>62F850</base>
-    </option>
-    <option name="v2.0.4.5">
-      <base>63FA28</base>
-    </option>
-    <option name="v2.0.7.5 and v2.0.9.1">
-      <base>6419F0</base>
-    </option>
-    <option name="v2.1.5.0">
-      <base>6BADC0</base>
-    </option>
-  </options>
+	<options>
+		<option name="v2.0.0.0">
+			<base>626588</base>
+		</option>
+		<option name="v2.0.1.2">
+			<base>62F850</base>
+		</option>
+		<option name="v2.0.2.7">
+			<base>62F850</base>
+		</option>
+		<option name="v2.0.4.5">
+			<base>63FA28</base>
+		</option>
+		<option name="v2.0.7.5">
+			<base>6419F0</base>
+		</option>
+		<option name="v2.0.9.1">
+			<base>6419F0</base>
+		</option>
+		<option name="v2.1.5.0">
+			<base>6BADC0</base>
+		</option>
+	</options>
 </game>
 <game name="Mirror's Edge Catalyst">
 	<process>MirrorsEdgeCatalyst</process>
@@ -126,21 +132,24 @@
 	<maximumValue>800</maximumValue>
 	<decimals>0</decimals>
 </game>
-<game name="Portal 2 (Single Player or Blue)">
+<game name="Portal 2">
 	<process>portal2</process>
 	<module>client.dll</module>
 	<base>09C4B24</base>
 	<offsets>100</offsets>
 	<type>FloatVec2</type>
 	<maximumValue>500</maximumValue>
-</game>
-<game name="Portal 2 (Orange)">
-	<process>portal2</process>
-	<module>client.dll</module>
-	<base>09C4B2C</base>
-	<offsets>100</offsets>
-	<type>FloatVec2</type>
-	<maximumValue>500</maximumValue>
+	<options>
+		<option name="Single Player">
+			<base>09C4B24</base>
+		</option>
+		<option name="Blue">
+			<base>09C4B24</base>
+		</option>
+		<option name="Orange">
+			<base>09C4B2C</base>
+		</option>
+	</options>
 </game>
 <game name="Quake (JoeQuake)">
 	<process>joequake-gl</process>
@@ -154,14 +163,14 @@
 	<offsets></offsets>
 	<type>FloatVec2</type>
 	<maximumValue>800</maximumValue>
-  <options>
-    <option name="Q2PRO 2014-12-03">
-      <base>15574C</base>
-    </option>
-    <option name="Q2PRO 2016-01-12">
-      <base>15674C</base>
-    </option>
-  </options>
+	<options>
+		<option name="Q2PRO 2014-12-03">
+			<base>15574C</base>
+		</option>
+		<option name="Q2PRO 2016-01-12">
+			<base>15674C</base>
+		</option>
+	</options>
 </game>
 <game name="RBDoom3BFG (1.1.0)">
 	<process>RBDoom3BFG</process>
@@ -186,42 +195,45 @@
 	<type>FloatVec2</type>
 	<maximumValue>600</maximumValue>
 	<unitConverter>45.00</unitConverter>
-  <options>
-    <option name="v1.1">
-      <base>C6C60</base>
-    </option>
-    <option name="v1.2">
-      <base>BB800</base>
-    </option>
-  </options>
+	<options>
+		<option name="v1.1">
+			<base>C6C60</base>
+		</option>
+		<option name="v1.2">
+			<base>BB800</base>
+		</option>
+	</options>
 </game>
 <game name="Star Wars Jedi Knight: Jedi Academy">
 	<process>jasp</process>
-	<base>00897B70</base>
-	<offsets>A4,3C</offsets>
-	<type>Float</type>
+	<options>
+		<option name="Normal">
+			<base>00897B70</base>
+			<offsets>A4,3C</offsets>
+			<type>Float</type>
+		</option>
+		<option name="vectors, no mounts">
+			<base>43FD48</base>
+			<offsets></offsets>
+			<type>FloatVec2</type>
+			<maximumValue>800</maximumValue>
+			<decimals>0</decimals>
+		</option>
+	</options>
 </game>
-<game name="Star Wars Jedi Knight: Jedi Academy (vectors, no mounts)">
-	<process>jasp</process>
-	<base>43FD48</base>
-	<offsets></offsets>
-	<type>FloatVec2</type>
-	<maximumValue>800</maximumValue>
-	<decimals>0</decimals>
-</game>
-<game name="Star Wars Jedi Knight: Jedi Outcast SP">
-	<process>jk2sp</process>
-	<base>41D4B8</base>
-	<offsets></offsets>
-	<type>FloatVec2</type>
-	<maximumValue>1000</maximumValue>
-</game>
-<game name="Star Wars Jedi Knight: Jedi Outcast MP">
-	<process>jk2mp</process>
-	<base>4F8F40</base>
-	<offsets></offsets>
+<game name="Star Wars Jedi Knight: Jedi Outcast">
 	<type>FloatVec2</type>
 	<maximumValue>1000</maximumValue>
+	<options>
+		<option name="SP">
+			<process>jk2sp</process>
+			<base>41D4B8</base>
+		</option>
+		<option name="MP">
+			<process>jk2mp</process>
+			<base>4F8F40</base>
+		</option>
+	</options>
 </game>
 <game name="The Elder Scrolls V: Skyrim">
 	<process>TESV</process>

--- a/XML/LiveSplit.MemoryGraphList.xml
+++ b/XML/LiveSplit.MemoryGraphList.xml
@@ -78,37 +78,37 @@
 	<module>client.dll</module>
 	<offsets></offsets>
 	<type>FloatVec2</type>
-  <versions>
-    <version name="V1.0">
+  <options>
+    <option name="V1.0">
       <base>4F0478</base>
-    </version>
-    <version name="Steam Version">
+    </option>
+    <option name="Steam option">
       <base>512208</base>
-    </version>
-  </versions>
+    </option>
+  </options>
 </game>
 <game name="Left 4 Dead 2">
 	<process>left4dead2</process>
 	<module>client.dll</module>
 	<offsets></offsets>
 	<type>FloatVec2</type>
-  <versions>
-    <version name="v2.0.0.0">
+  <options>
+    <option name="v2.0.0.0">
       <base>626588</base>
-    </version>
-    <version name="v2.0.1.2 and v2.0.2.7">
+    </option>
+    <option name="v2.0.1.2 and v2.0.2.7">
       <base>62F850</base>
-    </version>
-    <version name="v2.0.4.5">
+    </option>
+    <option name="v2.0.4.5">
       <base>63FA28</base>
-    </version>
-    <version name="v2.0.7.5 and v2.0.9.1">
+    </option>
+    <option name="v2.0.7.5 and v2.0.9.1">
       <base>6419F0</base>
-    </version>
-    <version name="v2.1.5.0">
+    </option>
+    <option name="v2.1.5.0">
       <base>6BADC0</base>
-    </version>
-  </versions>
+    </option>
+  </options>
 </game>
 <game name="Mirror's Edge Catalyst">
 	<process>MirrorsEdgeCatalyst</process>
@@ -154,14 +154,14 @@
 	<offsets></offsets>
 	<type>FloatVec2</type>
 	<maximumValue>800</maximumValue>
-  <versions>
-    <version name="Q2PRO 2014-12-03">
+  <options>
+    <option name="Q2PRO 2014-12-03">
       <base>15574C</base>
-    </version>
-    <version name="Q2PRO 2016-01-12">
+    </option>
+    <option name="Q2PRO 2016-01-12">
       <base>15674C</base>
-    </version>
-  </versions>
+    </option>
+  </options>
 </game>
 <game name="RBDoom3BFG (1.1.0)">
 	<process>RBDoom3BFG</process>
@@ -186,14 +186,14 @@
 	<type>FloatVec2</type>
 	<maximumValue>600</maximumValue>
 	<unitConverter>45.00</unitConverter>
-  <versions>
-    <version name="v1.1">
+  <options>
+    <option name="v1.1">
       <base>C6C60</base>
-    </version>
-    <version name="v1.2">
+    </option>
+    <option name="v1.2">
       <base>BB800</base>
-    </version>
-  </versions>
+    </option>
+  </options>
 </game>
 <game name="Star Wars Jedi Knight: Jedi Academy">
 	<process>jasp</process>


### PR DESCRIPTION
The current method of adding multiple versions or options to a game is to duplicate the XML tag and make the slight changes. With the recent inclusion of Left 4 Dead, which has many versions, this has made the game select look bad:

![ohgod](https://user-images.githubusercontent.com/36424682/36711319-bf21da62-1b50-11e8-9a2d-be85b2c2b0ab.PNG)

To fix this, I've added a new drop down. The game is still selected from the original drop down, but the version or option is selected with the second.

![cute](https://user-images.githubusercontent.com/36424682/36711379-04c4be5e-1b51-11e8-815e-f619becbcfc4.PNG)

![op](https://user-images.githubusercontent.com/36424682/36711334-d6db24e2-1b50-11e8-9021-16b431c107f8.PNG)

![nop](https://user-images.githubusercontent.com/36424682/36711387-09feba32-1b51-11e8-8feb-2bd1b7dd8804.PNG)

We'll also now save the selected game and option. This allows us to more easily switch the version or option.

This is backwards compatible with the old XML file. The old XML file will continue to be loaded until the user clicks the "Update XML file" button. Users with the old version of MemoryGraph dll will continue to be able to fetch the most recent version the old XML file.