### PR TITLE
Math Fix for Velocity calc in Component.cs (see description comment)

### DIFF
--- a/Component.cs
+++ b/Component.cs
@@ -21,7 +21,7 @@ namespace LiveSplit.MemoryGraph
             this.y = y;
         }
 
-        public double Norm => Math.Sqrt(x * x + y * y);
+        public double Norm => Math.Sqrt(x * x) + Math.Sqrt(y * y);
     }
 
     struct FloatVec2XZY
@@ -37,7 +37,7 @@ namespace LiveSplit.MemoryGraph
             this.z = z;
         }
 
-        public double Norm => Math.Sqrt(x * x + z * z);
+        public double Norm => Math.Sqrt(x * x) + Math.Sqrt(z * z);
     }
 
     struct FloatVec3
@@ -53,7 +53,7 @@ namespace LiveSplit.MemoryGraph
             this.z = z;
         }
 
-        public double Norm => Math.Sqrt(x * x + y * y + z * z);
+        public double Norm => Math.Sqrt(x * x) + Math.Sqrt(y * y) + Math.Sqrt(z * z);
     }
 
     struct IntVec2
@@ -67,7 +67,7 @@ namespace LiveSplit.MemoryGraph
             this.y = y;
         }
 
-        public double Norm => Math.Sqrt((double)x * x + (double)y * y);
+        public double Norm => Math.Sqrt((double)x * x) + Math.Sqrt((double)y * y);
     }
 
     struct IntVec2XZY
@@ -83,7 +83,7 @@ namespace LiveSplit.MemoryGraph
             this.z = z;
         }
 
-        public double Norm => Math.Sqrt((double)x * x + (double)z * z);
+        public double Norm => Math.Sqrt((double)x * x) + Math.Sqrt((double)z * z);
     }
 
     struct IntVec3
@@ -99,7 +99,7 @@ namespace LiveSplit.MemoryGraph
             this.z = z;
         }
 
-        public double Norm => Math.Sqrt((double)x * x + (double)y * y + (double)z * z);
+        public double Norm => Math.Sqrt((double)x * x) + Math.Sqrt((double)y * y) + Math.Sqrt((double)z * z);
     }
 
     public class Component : IComponent


### PR DESCRIPTION
I don't believe this component is currently calculating our total speed correctly, because it's doing the Sqrt with all axis values together instead of doing the Sqrts separately.
For example, I think your `Math.Sqrt(x * x + z * z)` should instead be `Math.Sqrt(x * x) + Math.Sqrt(z * z)`, because...
**Let's assume our velocities X=5 Z=10 for a speed of 15.**
If we do your current formula `√(5²+10²)` **we actually get 11 instead of 15**,
but if we do the Sqrts **_separately_** like this: `√(5²)+√(10²)` **we get the 15 we want**.
I tried to adjust all of your formulas in this file for this change, but I didn't actually compile to test them. I think this is correct, but I'm not 100% sure at the moment.
Screenshot of this issue: https://i.imgur.com/8ylhbyO.png (Cheat Engine on the left, LiveSplit component on the right)
(Your formula may already be correct and I'm just misunderstanding diagonal speed values)